### PR TITLE
add ability to store timing windows on creation of a new observation

### DIFF
--- a/src/main/webui/src/observations/edit.group.tsx
+++ b/src/main/webui/src/observations/edit.group.tsx
@@ -237,7 +237,7 @@ function ConvertToTimingWindowGui(input: TimingWindow) : TimingWindowGui {
 /**
  * Convert the TimingWindowGui type to a type appropriate to write to the
  * database.
- * Note: API expects the Dates as the number of seconds since the posix epoch
+ * Note: API expects the Dates as the number of milliseconds since the posix epoch
  *
  * @param {TimingWindowGui} input the timing window gui to convert to a
  * timing window api.
@@ -254,7 +254,10 @@ function ConvertToTimingWindowApi(input: TimingWindowGui) : TimingWindowApi {
 }
 
 /**
- * left as im sure this will be useful once we decide how to save
+ *
+ * //Piece of code relative to #20 add-edit-delete TimingWindows in existing Observations
+ *
+ * //This adds a new TimingWindow constraint to an existing observation
  *
  *  const handleSave = (timingWindow : TimingWindowApi) => {
  *         console.log(timingWindow)

--- a/src/main/webui/src/observations/edit.group.tsx
+++ b/src/main/webui/src/observations/edit.group.tsx
@@ -143,7 +143,11 @@ export default function ObservationEditGroup(
                     field: {
                         "@type": "proposal:TargetField",
                         "_id": values.fieldId
-                    }
+                    },
+                    constraints: values.timingWindows.map(
+                        (windowGui) => {
+                            return ConvertToTimingWindowApi(windowGui);
+                    })
                 }
 
                 let targetObservation =
@@ -214,6 +218,11 @@ export default function ObservationEditGroup(
 //We need to convert these to type Date before using them with the
 // 'DateTimePicker' element
 
+/**
+ * Convert the TimingWindow type from the database to a type appropriate for the UI
+ * @param {TimingWindow} input
+ * @return {TimingWindowGui}
+ */
 function ConvertToTimingWindowGui(input: TimingWindow) : TimingWindowGui {
     return ({
         startTime: new Date(input.startTime!),
@@ -224,32 +233,25 @@ function ConvertToTimingWindowGui(input: TimingWindow) : TimingWindowGui {
     })
 }
 
+// Note: API expects the Dates as the number of seconds since the posix epoch
+
+/**
+ * Convert the TimingWindowGui type to a type appropriate to write to the database
+ * @param {TimingWindowGui} input
+ * @return {TimingWindowApi}
+ */
+function ConvertToTimingWindowApi(input: TimingWindowGui) : TimingWindowApi {
+    return ({
+        "@type": "proposal:TimingWindow",
+        startTime: input.startTime!.getTime(),
+        endTime: input.endTime!.getTime(),
+        note: input.note,
+        isAvoidConstraint: input.isAvoidConstraint
+    })
+}
+
 /**
  * left as im sure this will be useful once we decide how to save
- *
- * // Note: API expects the Dates as the number of seconds since the posix epoch
- * // @ts-ignore
- * function ConvertToTimingWindowApi(input: TimingWindowGui) : TimingWindowApi {
- *     return ({
- *         "@type": "proposal:TimingWindow",
- *         startTime: input.startTime!.getTime(),
- *         endTime: input.endTime!.getTime(),
- *         note: input.note,
- *         isAvoidConstraint: input.isAvoidConstraint
- *     })
- * }
- *
- *
- *
- * //type to use to pass data to the API
- * type TimingWindowApi = {
- *     "@type": string,
- *     startTime: number,
- *     endTime: number,
- *     note: string,
- *     isAvoidConstraint: boolean,
- * }
- *
  *
  *  const handleSave = (timingWindow : TimingWindowApi) => {
  *         console.log(timingWindow)

--- a/src/main/webui/src/observations/edit.group.tsx
+++ b/src/main/webui/src/observations/edit.group.tsx
@@ -183,7 +183,7 @@ export default function ObservationEditGroup(
             else {
                 console.log("Editing");
             }
-        console.log(values)
+            console.debug(values)
     });
 
     return (
@@ -212,16 +212,17 @@ export default function ObservationEditGroup(
     )
 }
 
-
-//Type TimingWindow in proposalToolSchemas.ts has 'startTime' and
-// 'endTime' as date strings (ISO8601 strings).
-//We need to convert these to type Date before using them with the
-// 'DateTimePicker' element
-
 /**
- * Convert the TimingWindow type from the database to a type appropriate for the UI
- * @param {TimingWindow} input
- * @return {TimingWindowGui}
+ * Convert the TimingWindow type from the database to a type appropriate for
+ * the UI.
+ * NOTE: This is because the Type TimingWindow in proposalToolSchemas.ts has
+ * 'startTime' and 'endTime' as date strings (ISO8601 strings). We need
+ * to convert these to type Date before using them with the 'DateTimePicker'
+ * element.
+ *
+ * @param {TimingWindow} input the timing window to convert to a timing window
+ * gui.
+ * @return {TimingWindowGui} the converted timing window gui object.
  */
 function ConvertToTimingWindowGui(input: TimingWindow) : TimingWindowGui {
     return ({
@@ -233,12 +234,14 @@ function ConvertToTimingWindowGui(input: TimingWindow) : TimingWindowGui {
     })
 }
 
-// Note: API expects the Dates as the number of seconds since the posix epoch
-
 /**
- * Convert the TimingWindowGui type to a type appropriate to write to the database
- * @param {TimingWindowGui} input
- * @return {TimingWindowApi}
+ * Convert the TimingWindowGui type to a type appropriate to write to the
+ * database.
+ * Note: API expects the Dates as the number of seconds since the posix epoch
+ *
+ * @param {TimingWindowGui} input the timing window gui to convert to a
+ * timing window api.
+ * @return {TimingWindowApi} the converted timing window API object.
  */
 function ConvertToTimingWindowApi(input: TimingWindowGui) : TimingWindowApi {
     return ({

--- a/src/main/webui/src/observations/timingWindowApi.tsx
+++ b/src/main/webui/src/observations/timingWindowApi.tsx
@@ -1,11 +1,12 @@
-//type to use to pass data to the API - notice this is different to the TimingWindow
-//type in proposalToolSchemas.ts which uses strings for the dates
+//type to use to pass data to the API - notice this is different to the
+// TimingWindow type in proposalToolSchemas.ts which uses strings for the dates
 /**
  * @param {string} @type the object type i.e. 'proposal:TimingWindow'
  * @param {number} startTime the number of milliseconds since the posix epoch
  * @param {number} endTime the number of milliseconds since the posix epoch
  * @param {string} note optional description of the timing window
- * @param {boolean} isAvoidConstraint if true avoid observing between the dates given
+ * @param {boolean} isAvoidConstraint if true avoid observing between the dates
+ * given
  */
 type TimingWindowApi = {
     "@type": string,

--- a/src/main/webui/src/observations/timingWindowApi.tsx
+++ b/src/main/webui/src/observations/timingWindowApi.tsx
@@ -1,0 +1,16 @@
+//type to use to pass data to the API - notice this is different to the TimingWindow
+//type in proposalToolSchemas.ts which uses strings for the dates
+/**
+ * @param {string} @type the object type i.e. 'proposal:TimingWindow'
+ * @param {number} startTime the number of milliseconds since the posix epoch
+ * @param {number} endTime the number of milliseconds since the posix epoch
+ * @param {string} note optional description of the timing window
+ * @param {boolean} isAvoidConstraint if true avoid observing between the dates given
+ */
+type TimingWindowApi = {
+    "@type": string,
+    startTime: number,
+    endTime: number,
+    note: string,
+    isAvoidConstraint: boolean,
+}


### PR DESCRIPTION
Fixes issue #59.
- added 'TimingWindowApi' type to its own file in  the observations directory
- 'TimingWindowGui' converted to 'TimingWindowApi' when saving to the database