### PR TITLE
resolves #57 (locking out observations till targets and technical goals exist)

### DIFF
--- a/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
+++ b/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
@@ -4,6 +4,7 @@ Input property for common buttons:
 - onClick function (optional)
  */
 import { SyntheticEvent } from 'react';
+import { TablerIconsProps } from '@tabler/icons-react';
 
 /**
  * basic button interface props. Used by Submit button.
@@ -50,4 +51,15 @@ export interface DownloadButtonInterfaceProps extends BasicButtonInterfaceProps 
 export interface DownloadRequestInterfaceProps extends BasicButtonInterfaceProps {
     download: string
     onClick?: () => void
+}
+
+/**
+ * used to route users around the form from other pages.
+ */
+export interface NavigationButtonInterfaceProps
+        extends BasicButtonInterfaceProps {
+    p: number
+    ml: number
+    to: string
+    icon: (props: TablerIconsProps) => JSX.Element
 }

--- a/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
+++ b/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
@@ -55,6 +55,12 @@ export interface DownloadRequestInterfaceProps extends BasicButtonInterfaceProps
 
 /**
  * used to route users around the form from other pages.
+ *
+ * @param {number} p ??????
+ * @param {number} ml ????
+ * @param {string} to the destination to route the user to when clicked.
+ * @param {(props: TablerIconsProps) => JSX.Element} icon the mantine icon to
+ * present.
  */
 export interface NavigationButtonInterfaceProps
         extends BasicButtonInterfaceProps {

--- a/src/main/webui/src/commonButtons/navigation.tsx
+++ b/src/main/webui/src/commonButtons/navigation.tsx
@@ -1,0 +1,28 @@
+import { Button, Tooltip } from '@mantine/core';
+import { NavigationButtonInterfaceProps } from './buttonInterfaceProps.tsx';
+import { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * creates a navigation button.
+ *
+ * @param {NavigationButtonInterfaceProps} props the button inputs.
+ * @return {ReactElement} the dynamic html for the navigation button
+ * @constructor
+ */
+export default function NavigationButton(props: NavigationButtonInterfaceProps):
+    ReactElement {
+    return (
+        <Tooltip position={"left"} label={props.toolTipLabel} openDelay={1000}>
+            <Button rightSection={<props.icon size={"2rem"}/>}
+                    p={props.p}
+                    ml={props.ml}
+                    to={props.to}
+                    component={Link}
+                    variant={"subtle"}
+                    disabled={props.disabled}>
+                {props.label === undefined? 'unnamed route' : props.label}
+            </Button>
+        </Tooltip>
+    )
+}

--- a/src/main/webui/src/observations/observationPanel.tsx
+++ b/src/main/webui/src/observations/observationPanel.tsx
@@ -1,13 +1,19 @@
 import {
-    useObservationResourceGetObservations, useProposalResourceGetObservingProposalTitle, useProposalResourceGetTargets,
-} from "../generated/proposalToolComponents";
-import {Link, useParams} from "react-router-dom";
+    useObservationResourceGetObservations,
+    useProposalResourceGetObservingProposalTitle,
+    useProposalResourceGetTargets,
+    useTechnicalGoalResourceGetTechnicalGoals,
+} from '../generated/proposalToolComponents';
+import {useParams} from "react-router-dom";
 import ObservationRow, { observationTableHeader } from './observationTable.tsx';
-import {Badge, Button, Group, Space, Table, Text} from "@mantine/core";
+import {Badge, Group, Space, Table} from "@mantine/core";
 import {Observation} from "../generated/proposalToolSchemas.ts";
 import getErrorMessage from "../errorHandling/getErrorMessage.tsx";
 import { ReactElement } from 'react';
 import ObservationEditModal from './edit.modal.tsx';
+import NavigationButton from '../commonButtons/navigation.tsx';
+import { IconTarget, IconChartLine } from '@tabler/icons-react';
+
 
 
 /**
@@ -54,6 +60,7 @@ function ObservationsPanel(): ReactElement {
 function Observations() {
     const { selectedProposalCode} = useParams();
 
+    // get any observations from the database.
     const {
         data: observations ,
         error: observationsError,
@@ -64,37 +71,35 @@ function Observations() {
             );
 
 
+    // get any targets.
     const {data: targets, error: targetsError, isLoading: targetsLoading} =
         useProposalResourceGetTargets(
             {pathParams: {proposalCode: Number(selectedProposalCode)}},
             {enabled: true}
         );
 
+    // get any technical goals.
+    const {data: technicalGoals, error: technicalGoalError,
+           isLoading: technicalGaolsLoading} =
+        useTechnicalGoalResourceGetTechnicalGoals(
+            {pathParams: {proposalCode: Number(selectedProposalCode)}},
+            {enabled: true}
+        );
+
+    // get the title of the proposal.
     const {data: titleData, error: titleError, isLoading: titleLoading} =
         useProposalResourceGetObservingProposalTitle(
             {pathParams: {proposalCode: Number(selectedProposalCode)}}
         );
 
-    if (observationsError) {
+    /**
+     * generates the top header part of the panel.
+     *
+     * @return {React.ReactElement} the header dynamic HTML.
+     * @constructor
+     */
+    const Header = (): ReactElement => {
         return (
-            <pre>{getErrorMessage(observationsError)}</pre>
-        );
-    }
-
-    if (targetsError) {
-        return (
-            <pre>{getErrorMessage(targetsError)}</pre>
-        )
-    }
-
-    if (titleError) {
-        return (
-            <pre>{getErrorMessage(titleError)}</pre>
-        )
-    }
-
-    return (
-        <div>
             <h3>
                 { titleLoading ?
                     <Badge size={"xl"} radius={0}>...</Badge> :
@@ -102,11 +107,20 @@ function Observations() {
                 }
                 : Observations
             </h3>
+        )
+    }
 
-            {observationsLoading ? (`Loading...`) :
-                <Table>
-                    { observationTableHeader() }
-                    <Table.Tbody>
+    /**
+     * generates the observation table html.
+     *
+     * @return {React.ReactElement} the dynamic html for the observation table.
+     * @constructor
+     */
+    const TableGenerator = (): ReactElement => {
+        return (
+            <Table>
+                { observationTableHeader() }
+                <Table.Tbody>
                     {
                         observations?.map((observation) => {
                             return (
@@ -115,35 +129,129 @@ function Observations() {
                             )
                         })
                     }
-                    </Table.Tbody>
-                </Table>
-            }
+                </Table.Tbody>
+            </Table>
+        )
+    }
 
-            <Space h={"xs"}/>
+    /**
+     * produces the dynamic html for the technical goal button.
+     * @return {React.ReactElement} the dynamic html for the button.
+     * @constructor
+     */
+    const TechnicalGaolButton = (): ReactElement => {
+        return (
+            <NavigationButton
+                toolTipLabel={
+                    "Click to be routed to the technical goal page."}
+                p={5}
+                ml={-5}
+                icon={IconChartLine}
+                to={"../proposal/" + selectedProposalCode + "/goals"}
+                label={"at least one technical goal"}/>
+        )
+    }
 
+    /**
+     * produces the dynamic html for the target button.
+     * @return {React.ReactElement} the dynamic html for the button.
+     * @constructor
+     */
+    const TargetButton = (): ReactElement => {
+        return (
+            <NavigationButton
+                toolTipLabel={"Click to be routed to the target page."}
+                p={5}
+                ml={-5}
+                icon={IconTarget}
+                to={"../proposal/" + selectedProposalCode + "/targets"}
+                label={"at least one target"}/>
+        )
+    }
+
+    // process any errors.
+    const possibleErrors: (
+        {status: "unknown", payload: string} | null | undefined) [] = [
+            observationsError, targetsError, titleError, technicalGoalError];
+    const filtered: {status: "unknown", payload: string}[] =
+        possibleErrors.flatMap(f => f ? [f] : []);
+    if (filtered.length !== 0) {
+        let messages = "";
+        filtered.forEach((error: { status: "unknown", payload: string }) => {
+            messages = messages + " " + getErrorMessage(error);
+        })
+        return (<pre>messages</pre>);
+    }
+
+    // if still loading. present a loading screen.
+    if (targetsLoading || observationsLoading || technicalGaolsLoading ) {
+        return (
+            <div>
+                <Header/>
+                <Space h={"xs"}/>
+                <Group justify={'flex-end'}>
+                    `Loading...`
+                </Group>
+            </div>
+        )
+    }
+
+    // if no targets available, but technical goals exist, present a button to
+    // route the user back to targets
+    if (targets!.length === 0 && technicalGoals!.length !== 0) {
+        return (
+            <div>
+                <Header/>
+                <Group>
+                    To create an observation please add:
+                    <TargetButton/>
+                </Group>
+            </div>
+        );
+    }
+
+    // if no technical goals available, but targets exist, present a button to
+    // route the user back to technical goals
+    if (technicalGoals!.length === 0 && targets!.length !== 0) {
+        return (
+            <div>
+                <Header/>
+                <Group>
+                    To create an observation please add:
+                    <TechnicalGaolButton/>
+                </Group>
+            </div>
+        );
+    }
+
+    // if no technical goals or targets available. presnet buttons to route to
+    // either targets or technical goals.
+    if (technicalGoals!.length === 0 && targets!.length === 0) {
+        return (
+            <div>
+                <Header/>
+                <Group>
+                    To create an observation please add:
+                    <TargetButton/>
+                    and
+                    <TechnicalGaolButton/>
+                </Group>
+            </div>
+        );
+    }
+
+
+
+    // generate the table as we're in a safe state to do so.
+    return (
+        <div>
+            <Header/>
+            <TableGenerator/>
             <Group justify={'flex-end'}>
-                {targetsLoading ? (`Loading...`) :
-                    targets!.length > 0 ?
-                        <ObservationEditModal
-                            observation={undefined}
-                            newObservation={true}
-                        /> :
-                        <Group>
-                        <Text c={"yellow"} mr={-5}>
-                            To create an observation please add at least one
-                        </Text>
-                        <Button
-                            variant={"subtle"}
-                            p={5}
-                            ml={-5}
-                            to={"../proposal/" +
-                                selectedProposalCode + "/targets"}
-                            component={Link}
-                        >
-                            target
-                        </Button>
-                        </Group>
-                }
+                <ObservationEditModal
+                    observation={undefined}
+                    newObservation={true}
+                />
             </Group>
         </div>
     );


### PR DESCRIPTION
resolves #57 by doing the following:

1. creating a navigation button which handles routing to different parts of the UI. includes a parameterised icon, so could be the start for a generalised button code.
2. called hook for technical goals.
3. separated out the elements of the html in to functions, to try to make the html easier to read, and the fact that there is now a lot of ifs which would make the html even more nosier. these separations are:
         1. the header, 2. the table generator, 3. a technical goal button, 4. a target button, 
5. reduced the error code detection to present all errors, not just the first one found.
6. separated out the loading logic so its in one place. If its loading, it no longer presents the table, as clearly this is noise.
7. generated html for the 3 invalid states.
           1.  no targets, but technical goals exist, 2. no technical goals exist, but targets do, 3. no targets or technical goals exist.

simplified the "safe" state html to small amounts.


there is a open question over the icons i choose to represent targets and technical goals. If we're happy with those icons, it may be worth making them constants to import, so that we can apply them to the navigation bar as well. but that is left for a future ticket.