### PR TITLE
Djw 20 add edit delete timing windows existing observations

### DIFF
--- a/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
+++ b/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
@@ -56,8 +56,8 @@ export interface DownloadRequestInterfaceProps extends BasicButtonInterfaceProps
 /**
  * used to route users around the form from other pages.
  *
- * @param {number} p ??????
- * @param {number} ml ????
+ * @param {number} p CSS variable: element padding (left, top, right, and bottom)
+ * @param {number} ml CSS variable: element margin-left
  * @param {string} to the destination to route the user to when clicked.
  * @param {(props: TablerIconsProps) => JSX.Element} icon the mantine icon to
  * present.

--- a/src/main/webui/src/generated/proposalToolComponents.ts
+++ b/src/main/webui/src/generated/proposalToolComponents.ts
@@ -5570,63 +5570,6 @@ export const useObservationResourceGetObservations = <
   );
 };
 
-export type ObservationResourceAddObservationPathParams = {
-  /**
-   * @format int64
-   */
-  proposalCode: number;
-};
-
-export type ObservationResourceAddObservationError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type ObservationResourceAddObservationVariables = {
-  pathParams: ObservationResourceAddObservationPathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchObservationResourceAddObservation = (
-  variables: ObservationResourceAddObservationVariables,
-  signal?: AbortSignal
-) =>
-  proposalToolFetch<
-    undefined,
-    ObservationResourceAddObservationError,
-    undefined,
-    {},
-    {},
-    ObservationResourceAddObservationPathParams
-  >({
-    url: "/pst/api/proposals/{proposalCode}/observations",
-    method: "put",
-    ...variables,
-    signal,
-  });
-
-export const useObservationResourceAddObservation = (
-  options?: Omit<
-    reactQuery.UseMutationOptions<
-      undefined,
-      ObservationResourceAddObservationError,
-      ObservationResourceAddObservationVariables
-    >,
-    "mutationFn"
-  >
-) => {
-  const { fetcherOptions } = useProposalToolContext();
-  return reactQuery.useMutation<
-    undefined,
-    ObservationResourceAddObservationError,
-    ObservationResourceAddObservationVariables
-  >(
-    (variables: ObservationResourceAddObservationVariables) =>
-      fetchObservationResourceAddObservation({
-        ...fetcherOptions,
-        ...variables,
-      }),
-    options
-  );
-};
-
 export type ObservationResourceAddNewObservationPathParams = {
   /**
    * @format int64
@@ -5833,7 +5776,8 @@ export type ObservationResourceGetConstraintsPathParams = {
 export type ObservationResourceGetConstraintsError =
   Fetcher.ErrorWrapper<undefined>;
 
-export type ObservationResourceGetConstraintsResponse = Schemas.Constraint[];
+export type ObservationResourceGetConstraintsResponse =
+  Schemas.ObservingConstraint[];
 
 export type ObservationResourceGetConstraintsVariables = {
   pathParams: ObservationResourceGetConstraintsPathParams;
@@ -5909,7 +5853,7 @@ export type ObservationResourceAddNewConstraintError =
   Fetcher.ErrorWrapper<undefined>;
 
 export type ObservationResourceAddNewConstraintVariables = {
-  body?: Schemas.Constraint;
+  body?: Schemas.ObservingConstraint;
   pathParams: ObservationResourceAddNewConstraintPathParams;
 } & ProposalToolContext["fetcherOptions"];
 
@@ -5918,9 +5862,9 @@ export const fetchObservationResourceAddNewConstraint = (
   signal?: AbortSignal
 ) =>
   proposalToolFetch<
-    Schemas.Constraint,
+    Schemas.ObservingConstraint,
     ObservationResourceAddNewConstraintError,
-    Schemas.Constraint,
+    Schemas.ObservingConstraint,
     {},
     {},
     ObservationResourceAddNewConstraintPathParams
@@ -5934,7 +5878,7 @@ export const fetchObservationResourceAddNewConstraint = (
 export const useObservationResourceAddNewConstraint = (
   options?: Omit<
     reactQuery.UseMutationOptions<
-      Schemas.Constraint,
+      Schemas.ObservingConstraint,
       ObservationResourceAddNewConstraintError,
       ObservationResourceAddNewConstraintVariables
     >,
@@ -5943,7 +5887,7 @@ export const useObservationResourceAddNewConstraint = (
 ) => {
   const { fetcherOptions } = useProposalToolContext();
   return reactQuery.useMutation<
-    Schemas.Constraint,
+    Schemas.ObservingConstraint,
     ObservationResourceAddNewConstraintError,
     ObservationResourceAddNewConstraintVariables
   >(
@@ -5953,6 +5897,79 @@ export const useObservationResourceAddNewConstraint = (
         ...variables,
       }),
     options
+  );
+};
+
+export type ObservationResourceGetConstraintPathParams = {
+  /**
+   * @format int64
+   */
+  constraintId: number;
+  /**
+   * @format int64
+   */
+  observationId: number;
+};
+
+export type ObservationResourceGetConstraintError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type ObservationResourceGetConstraintVariables = {
+  pathParams: ObservationResourceGetConstraintPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchObservationResourceGetConstraint = (
+  variables: ObservationResourceGetConstraintVariables,
+  signal?: AbortSignal
+) =>
+  proposalToolFetch<
+    Schemas.ObservingConstraint,
+    ObservationResourceGetConstraintError,
+    undefined,
+    {},
+    {},
+    ObservationResourceGetConstraintPathParams
+  >({
+    url: "/pst/api/proposals/{proposalCode}/observations/{observationId}/constraints/{constraintId}",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export const useObservationResourceGetConstraint = <
+  TData = Schemas.ObservingConstraint
+>(
+  variables: ObservationResourceGetConstraintVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      Schemas.ObservingConstraint,
+      ObservationResourceGetConstraintError,
+      TData
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  const { fetcherOptions, queryOptions, queryKeyFn } =
+    useProposalToolContext(options);
+  return reactQuery.useQuery<
+    Schemas.ObservingConstraint,
+    ObservationResourceGetConstraintError,
+    TData
+  >(
+    queryKeyFn({
+      path: "/pst/api/proposals/{proposalCode}/observations/{observationId}/constraints/{constraintId}",
+      operationId: "observationResourceGetConstraint",
+      variables,
+    }),
+    ({ signal }) =>
+      fetchObservationResourceGetConstraint(
+        { ...fetcherOptions, ...variables },
+        signal
+      ),
+    {
+      ...options,
+      ...queryOptions,
+    }
   );
 };
 
@@ -6197,6 +6214,72 @@ export const useObservationResourceReplaceTechnicalGoal = (
   >(
     (variables: ObservationResourceReplaceTechnicalGoalVariables) =>
       fetchObservationResourceReplaceTechnicalGoal({
+        ...fetcherOptions,
+        ...variables,
+      }),
+    options
+  );
+};
+
+export type ObservationResourceReplaceTimingWindowPathParams = {
+  /**
+   * @format int64
+   */
+  observationId: number;
+  /**
+   * @format int64
+   */
+  proposalCode: number;
+  /**
+   * @format int64
+   */
+  timingWindowId: number;
+};
+
+export type ObservationResourceReplaceTimingWindowError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type ObservationResourceReplaceTimingWindowVariables = {
+  body?: Schemas.TimingWindow;
+  pathParams: ObservationResourceReplaceTimingWindowPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchObservationResourceReplaceTimingWindow = (
+  variables: ObservationResourceReplaceTimingWindowVariables,
+  signal?: AbortSignal
+) =>
+  proposalToolFetch<
+    Schemas.TimingWindow,
+    ObservationResourceReplaceTimingWindowError,
+    Schemas.TimingWindow,
+    {},
+    {},
+    ObservationResourceReplaceTimingWindowPathParams
+  >({
+    url: "/pst/api/proposals/{proposalCode}/observations/{observationId}/timingWindows/{timingWindowId}",
+    method: "put",
+    ...variables,
+    signal,
+  });
+
+export const useObservationResourceReplaceTimingWindow = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      Schemas.TimingWindow,
+      ObservationResourceReplaceTimingWindowError,
+      ObservationResourceReplaceTimingWindowVariables
+    >,
+    "mutationFn"
+  >
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    Schemas.TimingWindow,
+    ObservationResourceReplaceTimingWindowError,
+    ObservationResourceReplaceTimingWindowVariables
+  >(
+    (variables: ObservationResourceReplaceTimingWindowVariables) =>
+      fetchObservationResourceReplaceTimingWindow({
         ...fetcherOptions,
         ...variables,
       }),
@@ -8245,6 +8328,11 @@ export type QueryOperation =
       path: "/pst/api/proposals/{proposalCode}/observations/{observationId}/constraints";
       operationId: "observationResourceGetConstraints";
       variables: ObservationResourceGetConstraintsVariables;
+    }
+  | {
+      path: "/pst/api/proposals/{proposalCode}/observations/{observationId}/constraints/{constraintId}";
+      operationId: "observationResourceGetConstraint";
+      variables: ObservationResourceGetConstraintVariables;
     }
   | {
       path: "/pst/api/proposals/{proposalCode}/supportingDocuments";

--- a/src/main/webui/src/generated/proposalToolSchemas.ts
+++ b/src/main/webui/src/generated/proposalToolSchemas.ts
@@ -130,7 +130,7 @@ export type CalibrationObservation = {
   /**
    * any constraints on the observation
    */
-  constraints?: Constraint[];
+  constraints?: ObservingConstraint[];
   /**
    * A target source
    */
@@ -212,11 +212,6 @@ export type CommitteeMember = {
    */
   member?: Reviewer;
 };
-
-/**
- * a form of constraint on the observation
- */
-export type Constraint = Record<string, any>;
 
 /**
  * Axis description for continuous data. This object describes the domain for a particular axis of the domain space. It allows for the specification of the legal domain range (min,max), and a flag indicating if the axis is cyclic.
@@ -579,7 +574,7 @@ export type Observation = {
   /**
    * any constraints on the observation
    */
-  constraints?: Constraint[];
+  constraints?: ObservingConstraint[];
   /**
    * A target source
    */
@@ -643,6 +638,11 @@ export type ObservingConfiguration = {
    */
   backend?: Backend;
 };
+
+/**
+ * a form of constraint on the observation
+ */
+export type ObservingConstraint = Record<string, any>;
 
 /**
  * a collection of configs that can be chosen to observe with.
@@ -1394,7 +1394,7 @@ export type TargetObservation = {
   /**
    * any constraints on the observation
    */
-  constraints?: Constraint[];
+  constraints?: ObservingConstraint[];
   /**
    * A target source
    */
@@ -1520,6 +1520,9 @@ export type TimingConstraint = {
  */
 export type TimingWindow = {
   "@type"?: string; //proposal:TimingWindow
+
+  _id?: number;
+
   note?: string;
   isAvoidConstraint?: boolean;
   /**

--- a/src/main/webui/src/observations/edit.group.tsx
+++ b/src/main/webui/src/observations/edit.group.tsx
@@ -1,7 +1,7 @@
 import TargetTypeForm from "./targetType.form.tsx";
 import TimingWindowsForm from "./timingWindows.form.tsx";
 import {ObservationProps} from "./observationPanel.tsx";
-import { Fieldset, Grid, Group } from '@mantine/core';
+import { Fieldset, Grid, Group, Text } from '@mantine/core';
 import {
     CalibrationObservation,
     CalibrationTargetIntendedUse, Observation, TargetObservation,
@@ -10,7 +10,9 @@ import {
 import { useForm, UseFormReturnType } from '@mantine/form';
 import {
     fetchObservationResourceAddNewConstraint,
-    fetchObservationResourceAddNewObservation, fetchObservationResourceReplaceTimingWindow
+    fetchObservationResourceAddNewObservation, fetchObservationResourceReplaceField,
+    fetchObservationResourceReplaceTarget, fetchObservationResourceReplaceTechnicalGoal,
+    fetchObservationResourceReplaceTimingWindow
 } from '../generated/proposalToolComponents.ts';
 import { SubmitButton } from '../commonButtons/save.tsx';
 import { useParams } from 'react-router-dom';
@@ -219,10 +221,50 @@ export default function ObservationEditGroup(
                     //else do nothing
                 })
 
-                //Todo: include any changes to the other values (target, technical goal, field)
+                if (form.isDirty('targetDBId')) {
+                    fetchObservationResourceReplaceTarget({
+                        pathParams: {
+                            proposalCode: Number(selectedProposalCode),
+                            observationId: props.observationId!
+                        },
+                        body: {
+                            "@type": "proposal:CelestialTarget",
+                            "_id": form.values.targetDBId
+                        }
+                    })
+                        .then(()=>queryClient.invalidateQueries())
+                        .catch(console.error)
+                }
 
+                if (form.isDirty('techGoalId')) {
+                    fetchObservationResourceReplaceTechnicalGoal({
+                        pathParams: {
+                            proposalCode: Number(selectedProposalCode),
+                            observationId: props.observationId!
+                        },
+                        body: {
+                            "_id": form.values.techGoalId
+                        }
+                    })
+                        .then(()=>queryClient.invalidateQueries())
+                        .catch(console.error)
+                }
+
+                if (form.isDirty('fieldId')) {
+                    fetchObservationResourceReplaceField({
+                        pathParams: {
+                            proposalCode: Number(selectedProposalCode),
+                            observationId: props.observationId!
+                        },
+                        body: {
+                            "@type": "proposal:TargetField",
+                            "_id": form.values.fieldId
+                        }
+                    })
+                        .then(()=>queryClient.invalidateQueries())
+                        .catch(console.error)
+                }
             }
-            console.debug(values)
     });
 
     return (
@@ -243,6 +285,9 @@ export default function ObservationEditGroup(
                     </Grid.Col>
                     <Grid.Col span={{base: 5, lg: 3}}>
                         <Fieldset legend={"Timing windows"}>
+                            <Text ta={"center"}  size={"xs"} c={"gray.6"}>
+                                Timezone set to UTC
+                            </Text>
                             <TimingWindowsForm {...form}/>
                         </Fieldset>
                     </Grid.Col>

--- a/src/main/webui/src/observations/edit.group.tsx
+++ b/src/main/webui/src/observations/edit.group.tsx
@@ -28,7 +28,8 @@ type ObservationType = 'Target' | 'Calibration' | '';
  * the interface for the entire observation form.
  */
 export interface ObservationFormValues {
-    observationType: ObservationType;
+    observationId: number | undefined,
+    observationType: ObservationType,
     calibrationUse: CalibrationTargetIntendedUse | undefined,
     targetDBId: number | undefined,
     techGoalId: number | undefined,
@@ -92,6 +93,7 @@ export default function ObservationEditGroup(
     const form: UseFormReturnType<ObservationFormValues> =
         useForm<ObservationFormValues>({
             initialValues: {
+                observationId: props.observationId, //required for deletion of timing windows
                 observationType: observationType,
                 calibrationUse: calibrationUse,
                 targetDBId: props.observation?.target?._id,

--- a/src/main/webui/src/observations/edit.modal.tsx
+++ b/src/main/webui/src/observations/edit.modal.tsx
@@ -43,7 +43,9 @@ export default function ObservationEditModal(
                 <Modal
                     opened={opened}
                     onClose={props.closeModal}
-                    title={"View/Edit Observation Form"}
+                    title={newObservation ?
+                        "New Observation" :
+                        "View/Edit Observation"}
                     fullScreen
                 >
                     <ObservationEditGroup {...props}/>
@@ -54,20 +56,14 @@ export default function ObservationEditModal(
 
     // main code starts here.
     const [opened, {close, open}] = useDisclosure();
-
     const props = {...observationProps, closeModal: () => {close()}};
+    let newObservation = !observationProps.observation;
 
-    if (props.newObservation) {
-        return (
-            <>
-                <NewButton/>
-                <ModalHtml/>
-            </>
-        );
-    }
     return (
         <>
-            <EditButton/>
+            {newObservation ?
+                <NewButton/> : <EditButton/>
+            }
             <ModalHtml/>
         </>
     )

--- a/src/main/webui/src/observations/observationPanel.tsx
+++ b/src/main/webui/src/observations/observationPanel.tsx
@@ -15,13 +15,12 @@ import NavigationButton from '../commonButtons/navigation.tsx';
 import { IconTarget, IconChartLine } from '@tabler/icons-react';
 
 
-
 /**
  * the observation props.
- * @param {Observation | undefined} observation the observation object, or
- * undefined if not populated.
- * @param {number} observationId the observation id.
- * @param {() => void}} closeModal an optional close modal.
+ * @param {Observation | undefined} observation the observation object or
+ * undefined if not populated
+ * @param {number} observationId the observation id - optional
+ * @param {() => void}} closeModal an optional close modal - optional
  */
 export type ObservationProps = {
     observation: Observation | undefined,
@@ -29,12 +28,6 @@ export type ObservationProps = {
     observationId?: number,
     closeModal?: () => void
 }
-
-/*
-       TODO:
-       1. provide better UX for errors
-       2. provide functionality to edit an observation
- */
 
 /**
  * generates the observation panel.
@@ -219,7 +212,7 @@ function Observations() {
         );
     }
 
-    // if no technical goals or targets available. presnet buttons to route to
+    // if no technical goals or targets available. present buttons to route to
     // either targets or technical goals.
     if (technicalGoals!.length === 0 && targets!.length === 0) {
         return (
@@ -235,14 +228,13 @@ function Observations() {
         );
     }
 
-
-
     // generate the table as we're in a safe state to do so.
     return (
         <div>
             <Header/>
             <TableGenerator/>
-            <Group justify={'flex-end'}>
+            <Space h={"xl"}/>
+            <Group justify={'center'}>
                 <ObservationEditModal observation={undefined}/>
             </Group>
         </div>

--- a/src/main/webui/src/observations/observationPanel.tsx
+++ b/src/main/webui/src/observations/observationPanel.tsx
@@ -21,17 +21,12 @@ import { IconTarget, IconChartLine } from '@tabler/icons-react';
  * @param {Observation | undefined} observation the observation object, or
  * undefined if not populated.
  * @param {number} observationId the observation id.
- * @param {boolean} newObservation a optional parameter stating if it is a new
- * observation.
  * @param {() => void}} closeModal an optional close modal.
  */
 export type ObservationProps = {
     observation: Observation | undefined,
     // needed as 'observation' does not contain its database id
     observationId?: number,
-    // this might be redundant i.e. observation === undefined contains the
-    // information
-    newObservation: boolean,
     closeModal?: () => void
 }
 
@@ -248,10 +243,7 @@ function Observations() {
             <Header/>
             <TableGenerator/>
             <Group justify={'flex-end'}>
-                <ObservationEditModal
-                    observation={undefined}
-                    newObservation={true}
-                />
+                <ObservationEditModal observation={undefined}/>
             </Group>
         </div>
     );

--- a/src/main/webui/src/observations/observationTable.tsx
+++ b/src/main/webui/src/observations/observationTable.tsx
@@ -168,16 +168,6 @@ export default function ObservationRow(
         performance.desiredLargestScale?.value === undefined;
 
 
-    /*
-    On startup this code triggers the following in warning (in Chrome at least):
-        Warning: validateDOMNesting(...): Text nodes cannot appear as a child
-        of <tbody>
-    I have yet to track down the cause. I suspect either one-of the
-    'Loading...' texts or possibly the observation type text. Note the warning
-    disappears after the initial render so the 'Loading...' texts are prime
-    suspects.
-     */
-
     // if loading, present a loading.
     if (observationLoading) {
         return (

--- a/src/main/webui/src/observations/observationTable.tsx
+++ b/src/main/webui/src/observations/observationTable.tsx
@@ -84,7 +84,7 @@ export default function ObservationRow(
     }
 
     /**
-     * handles the confirmation to the user for deletion of an obersation.
+     * handles the confirmation to the user for deletion of an observation.
      */
     const confirmDeletion = () => modals.openConfirmModal({
         title: 'Delete Observation?',
@@ -265,7 +265,6 @@ export default function ObservationRow(
                         <ObservationEditModal
                             observation={observation}
                             observationId={observationId.id}
-                            newObservation={false}
                         />
                     }
                     <CloneButton toolTipLabel={"clone"}

--- a/src/main/webui/src/observations/targetType.form.tsx
+++ b/src/main/webui/src/observations/targetType.form.tsx
@@ -4,7 +4,7 @@ import {
 import {
     Container,
     Select,
-    Space
+    Space, Tooltip
 } from "@mantine/core";
 import {useParams} from "react-router-dom";
 import {RenderTarget} from "../targets/RenderTarget.tsx";
@@ -12,14 +12,14 @@ import {RenderTechnicalGoal} from "../technicalGoals/render.technicalGoal.tsx";
 import { ReactElement } from 'react';
 import { UseFormReturnType } from '@mantine/form';
 import { ObservationFormValues } from './edit.group.tsx';
-import { JSON_SPACES } from '../constants.tsx';
+import {JSON_SPACES, OPEN_DELAY} from '../constants.tsx';
 import { randomId } from '@mantine/hooks';
 
 /**
  * the entrance to building the target part of the edit panel.
  *
- * TODO try to find the actual type for the form. as any is a dire type.
- * @param {any} form the form that governs the entire observation edit.
+ * @param {UseFormReturnType<ObservationFormValues>} form the form that governs
+ * the entire observation edit.
  * @return {ReactElement} the HTML for the observation edit panel.
  * @constructor
  */
@@ -121,20 +121,29 @@ export default function TargetTypeForm (
     }
 
     /**
-     * generates the html for the observation type.
+     * generates the html for the observation type. Notice, disabled if editing
+     * an existing observation
      * @return {ReactElement} the html for the observation type.
-     * @constructor
+     *
      */
     function SelectObservationType(): ReactElement {
         return (
-            <Select
-                label={"Observation type: "}
-                placeholder={"select observation type"}
-                data = {[
-                    'Target', 'Calibration'
-                ]}
-                {...form.getInputProps('observationType')}
-            />
+            <Tooltip
+                label={form.values.observationId !== undefined ?
+                    "Cannot change the type of an existing Observation" :
+                    'Target object or Calibration object'}
+                openDelay={OPEN_DELAY}
+            >
+                <Select
+                    label={"Observation type: "}
+                    placeholder={"select observation type"}
+                    disabled={form.values.observationId !== undefined}
+                    data = {[
+                        'Target', 'Calibration'
+                    ]}
+                    {...form.getInputProps('observationType')}
+                />
+            </Tooltip>
         )
     }
 
@@ -180,6 +189,7 @@ export default function TargetTypeForm (
                         boundTargets={[]}
                     />
             }
+            <Space h={"sm"}/>
             {SelectTechnicalGoal()}
             {
                 technicalGoalsLoading ? 'loading...' :
@@ -189,10 +199,13 @@ export default function TargetTypeForm (
                         dbid={form.values.techGoalId}
                     />
             }
-            <Space h={"xl"}/>
+            <Space h={"sm"}/>
             {SelectObservationType()}
             {form.values.observationType === 'Calibration' &&
-                SelectCalibrationUse()
+                <>
+                    <Space h={"xs"}/>
+                    {SelectCalibrationUse()}
+                </>
             }
         </Container>
     );

--- a/src/main/webui/src/observations/timingWindowApi.tsx
+++ b/src/main/webui/src/observations/timingWindowApi.tsx
@@ -6,6 +6,7 @@
  * @param {number} endTime the number of milliseconds since the posix epoch
  * @param {string} note optional description of the timing window
  * @param {boolean} isAvoidConstraint if true avoid observing between the dates
+ * @param {number} _id the database id for the window or zero if new
  * given
  */
 type TimingWindowApi = {
@@ -14,4 +15,5 @@ type TimingWindowApi = {
     endTime: number,
     note: string,
     isAvoidConstraint: boolean,
+    _id: number
 }

--- a/src/main/webui/src/observations/timingWindowGui.tsx
+++ b/src/main/webui/src/observations/timingWindowGui.tsx
@@ -4,12 +4,14 @@
  * @param {Date | null} endTime the date the timing window will end.
  * @param {string} note the optional note.
  * @param {boolean} isAvoidConstraint
- * @param {string} key the primary key in the database.
+ * @param {string} key the primary key in the database or a random string if new.
+ * @param {number} id the database id for the window or zero if new
  */
 export type TimingWindowGui = {
     startTime: Date | null,
     endTime: Date | null,
     note: string,
     isAvoidConstraint: boolean,
-    key: string
+    key: string,
+    id: number
 }

--- a/src/main/webui/src/observations/timingWindows.form.tsx
+++ b/src/main/webui/src/observations/timingWindows.form.tsx
@@ -18,16 +18,6 @@ import { TimingWindowGui } from './timingWindowGui.tsx';
 // observation. These are stored as a List of Constraints in the Observation in
 // the backend. TimingWindows may not be the only Constraints.
 
-//FIXME: This currently only ADDS new timing windows to the specified
-// observation.
-// -- for example, it will display all currently added timing windows and if
-// you try to edit one of those (and press the 'save' button) it will instead
-// add a new timing window with the new data (note this won't show up until you
-// close and re-open the modal).
-// We need to be able to edit existing timing windows or at least be able to
-// delete them to replace them with a new window.
-// -- this issue stems from having no access to the timing window database IDs
-
 //As a general reminder, Radio observations can be done at any time but
 // Optical observations can occur only after sunset. In both cases the target
 // must be above the horizon at the time
@@ -47,7 +37,8 @@ export default function TimingWindowsForm(
         endTime: null,
         note: '',
         isAvoidConstraint: false,
-        key: randomId()
+        key: randomId(),
+        id: 0
     }
 
     //Note: using Grid and Grid.Col to get the spacing correct for each element.
@@ -65,6 +56,9 @@ export default function TimingWindowsForm(
 
     // how many columns the note field requires.
     const MAX_COLUMNS_NOTE = 3;
+
+    //character limit for the optional note about the timing window
+    const MAX_CHARS = 150;
 
     /**
      * handles the deletion of a timing window.
@@ -134,10 +128,10 @@ export default function TimingWindowsForm(
                                     autosize
                                     minRows={3}
                                     maxRows={3}
-                                    maxLength={150}
+                                    maxLength={MAX_CHARS}
                                     description={
-                                        150 -
-                                        form.values.timingWindows[index].note.length + "/150"}
+                                        MAX_CHARS -
+                                        form.values.timingWindows[index].note.length + "/" + String(MAX_CHARS)}
                                     inputWrapperOrder={[
                                         'label', 'error', 'input', 'description']}
                                     placeholder={"add optional note"}

--- a/src/main/webui/src/observations/timingWindows.form.tsx
+++ b/src/main/webui/src/observations/timingWindows.form.tsx
@@ -95,6 +95,11 @@ export default function TimingWindowsForm(
             .catch(console.error);
     }
 
+    /**
+     * Pops up a confirmation modal for the user before deletion
+     * @param {number} index the map index of the timing window
+     * @param {number} timingWindowId the database id of the timing window
+     */
     const confirmDeletion = (index: number, timingWindowId: number) =>
         modals.openConfirmModal( {
             title: 'Delete Timing Window?',

--- a/src/main/webui/src/observations/timingWindows.form.tsx
+++ b/src/main/webui/src/observations/timingWindows.form.tsx
@@ -1,5 +1,5 @@
 import {Accordion, Grid, Group, Space, Switch, Textarea, Text} from "@mantine/core";
-import {DateTimePicker} from "@mantine/dates";
+import {DatesProvider, DateTimePicker} from "@mantine/dates";
 import { UseFormReturnType } from '@mantine/form';
 import {randomId} from "@mantine/hooks";
 
@@ -25,7 +25,7 @@ import {notifications} from "@mantine/notifications";
 
 //As a general reminder, Radio observations can be done at any time but
 // Optical observations can occur only after sunset. In both cases the target
-// must be above the horizon at the time
+// must be above the horizon at the time.
 
 /**
  *
@@ -67,7 +67,7 @@ export default function TimingWindowsForm(
     const MAX_COLUMNS_NOTE = 3;
 
     //character limit for the optional note about the timing window
-    const MAX_CHARS = 150;
+    const MAX_CHARS_NOTE = 150;
 
     /**
      * handles the deletion of a timing window.
@@ -108,7 +108,6 @@ export default function TimingWindowsForm(
                     <Text c={"yellow"} size={"sm"}>
                         Removes Timing Window {index + 1} from the Observation
                     </Text>
-                    <Space h={"sm"}/>
                 </>
             ),
             labels: {confirm: 'Delete', cancel: "No don't delete it"},
@@ -150,6 +149,8 @@ export default function TimingWindowsForm(
                                     minDate={new Date()}
                                     {...form.getInputProps(
                                         `timingWindows.${index}.startTime`)}
+                                    rightSection={<Text>start</Text>}
+                                    rightSectionWidth={50}
                                 />
                                 <Space h={"xs"}/>
                                 <DateTimePicker
@@ -157,6 +158,8 @@ export default function TimingWindowsForm(
                                     minDate={new Date()}
                                     {...form.getInputProps(
                                         `timingWindows.${index}.endTime`)}
+                                    rightSection={<Text>end</Text>}
+                                    rightSectionWidth={50}
                                 />
                             </Grid.Col>
                             <Grid.Col span={{
@@ -181,10 +184,11 @@ export default function TimingWindowsForm(
                                     autosize
                                     minRows={3}
                                     maxRows={3}
-                                    maxLength={MAX_CHARS}
+                                    maxLength={MAX_CHARS_NOTE}
                                     description={
-                                        MAX_CHARS -
-                                        form.values.timingWindows[index].note.length + "/" + String(MAX_CHARS)}
+                                        MAX_CHARS_NOTE -
+                                        form.values.timingWindows[index].note.length +
+                                        "/" + String(MAX_CHARS_NOTE)}
                                     inputWrapperOrder={[
                                         'label', 'error', 'input', 'description']}
                                     placeholder={"add optional note"}
@@ -199,11 +203,12 @@ export default function TimingWindowsForm(
     });
 
     return (
-        <>
+        <DatesProvider settings={{timezone: 'UTC'}}>
             <Accordion defaultValue={"1"} chevronPosition={"left"}>
                 {windowsList}
             </Accordion>
-            <Group justify={"flex-end"}>
+            <Space h={"lg"}/>
+            <Group justify={"center"}>
                 <AddButton
                     toolTipLabel={"add a timing window"}
                     onClick={() => form.insertListItem(
@@ -211,6 +216,6 @@ export default function TimingWindowsForm(
                         {...EMPTY_TIMING_WINDOW, key: randomId()})}
                 />
             </Group>
-        </>
+        </DatesProvider>
     )
 }


### PR DESCRIPTION
- add, edit and delete TimingWindows in existing Observations
- able to change the Target and TechnicalGoal in existing Observations
- disable the "Observation type" Select input for an existing Observation 
- use DateProvider around DateTimePickers to use timezone: UTC
- justify "centre" the "Add" new observation and the "Add" new timing window buttons 

New Issues:
- On changing the target of an existing Observation i.e., selecting a new target id and pressing "Save", the "view/edit" modal closes; it shouldn't do that and I don't know why it does. Editing any other value does not close the modal as programmed. 
- There's no API call to update the "intended use" of a Calibration Observation. 