### PR TITLE
99 duplicate targets

### DIFF
--- a/src/main/webui/src/targets/New.tsx
+++ b/src/main/webui/src/targets/New.tsx
@@ -312,7 +312,7 @@ const TargetForm = (props: FormPropsType<newTargetData>): ReactElement => {
                         label="Name"
                         placeholder="Name of target"
                         {...form.getInputProps("TargetName")}
-                        onChange={(e) => {
+                        onChange={(e: string) => {
                             setNameUnique(true);
                             if(form.getInputProps("TargetName").onChange)
                                 form.getInputProps("TargetName").onChange(e);

--- a/src/main/webui/src/targets/New.tsx
+++ b/src/main/webui/src/targets/New.tsx
@@ -7,7 +7,7 @@ import {
     ReactElement,
     ReactNode,
     useEffect,
-    useRef
+    useRef, useState
 } from 'react';
 import {
     CelestialTarget,
@@ -71,6 +71,7 @@ const ALADIN_STATE_NAME = "hasDoneAladin";
  * @constructor
  */
 const TargetForm = (props: FormPropsType<newTargetData>): ReactElement => {
+    const [nameUnique, setNameUnique] = useState(true);
     const form = useForm({
             initialValues: props.initialValues ?? {
                 TargetName: "",
@@ -82,7 +83,7 @@ const TargetForm = (props: FormPropsType<newTargetData>): ReactElement => {
             },
             validate: {
                 TargetName: (value) => (
-                    value.length < 1 ? 'Name cannot be blank ' : null),
+                    value.length < 1 ? 'Name cannot be blank ' : nameUnique? null : 'Source name must be unique'),
                 RA: (value) => (
                     value === null || value === undefined ?
                         'RA cannot be blank':
@@ -179,6 +180,7 @@ const TargetForm = (props: FormPropsType<newTargetData>): ReactElement => {
                 queryParams: {sourceName: val.TargetName}})
             .then((data) => {
                 if(data.length == 0) {
+                    setNameUnique(true);
                     fetchSpaceSystemResourceGetSpaceSystem(
                         {pathParams: { frameCode: 'ICRS'}})
                         .then((spaceSys) => assignSpaceSys(spaceSys))
@@ -193,6 +195,7 @@ const TargetForm = (props: FormPropsType<newTargetData>): ReactElement => {
                         .catch(console.log);
                 } else {
                     //Target already exists on this proposal
+                    setNameUnique(false);
                     notifications.show({
                         autoClose:5000,
                         title:"Duplicate target",
@@ -308,7 +311,13 @@ const TargetForm = (props: FormPropsType<newTargetData>): ReactElement => {
                         withAsterisk
                         label="Name"
                         placeholder="Name of target"
-                        {...form.getInputProps("TargetName")} />
+                        {...form.getInputProps("TargetName")}
+                        onChange={(e) => {
+                            setNameUnique(true);
+                            if(form.getInputProps("TargetName").onChange)
+                                form.getInputProps("TargetName").onChange(e);
+                        }}
+                    />
                     <DatabaseSearchButton
                         label={"Lookup"}
                         onClick={simbadLookup}

--- a/src/main/webui/src/targets/TargetTable.tsx
+++ b/src/main/webui/src/targets/TargetTable.tsx
@@ -49,7 +49,6 @@ function TargetTableRow(props: TargetProps): ReactElement {
     const queryClient = useQueryClient();
     const [submitting, setSubmitting] = useState(false);
 
-    console.debug(`get target id of ${props.dbid}`)
     const {data, error, isLoading}
         = useProposalResourceGetTarget(
         {pathParams:
@@ -77,7 +76,6 @@ function TargetTableRow(props: TargetProps): ReactElement {
      */
     function handleRemove(): void {
         setSubmitting(true);
-        console.debug(`start delete of target ${props.dbid}`);
         fetchProposalResourceRemoveTarget({pathParams:
                 {
                     proposalCode: props.proposalCode,
@@ -85,7 +83,6 @@ function TargetTableRow(props: TargetProps): ReactElement {
                 }})
             .then(()=> {
                 setSubmitting(false);
-                console.debug("delete complete");
                 return queryClient.invalidateQueries(
                     {
                         predicate: (query) => {


### PR DESCRIPTION
Stops a GUI user from adding two targets with identical names to the same proposal.

Name checking is case sensitive as that's what the API currently does when you request a named target on a given proposal.

The check is partly integrated into the form validation, so when a duplicate name is submitted the form is invalidated until the source name is changed.