### PR TITLE
122 manager view create proposal cycles

### DIFF
--- a/src/main/webui/Add_@types.patch
+++ b/src/main/webui/Add_@types.patch
@@ -1,5 +1,5 @@
---- proposalToolSchemas.ts.orig	2024-04-08 14:56:39
-+++ proposalToolSchemas.ts	2024-04-08 14:57:40
+--- proposalToolSchemas.ts.orig	2024-04-08 13:41:12
++++ proposalToolSchemas.ts	2024-04-19 12:26:18
 @@ -129,6 +129,7 @@
   * An observation that is intended for calibration
   */
@@ -8,7 +8,28 @@
    /**
     * any constraints on the observation
     */
-@@ -162,6 +163,7 @@
+@@ -149,19 +150,20 @@
+ };
+ 
+ export type CalibrationTargetIntendedUse =
+-  | "AMPLITUDE"
+-  | "ATMOSPHERIC"
+-  | "BANDPASS"
+-  | "PHASE"
+-  | "POINTING"
+-  | "FOCUS"
+-  | "POLARIZATION"
+-  | "DELAY";
++  | "Amplitude"
++  | "Atmospheric"
++  | "Bandpass"
++  | "Phase"
++  | "Pointing"
++  | "Focus"
++  | "Polarization"
++  | "Delay";
+ 
+ /**
   * Spatial domain, three-dimensional cartesian coordinate space. The particulars of the axis descriptions depend on the physical constraints of the instance. In Appendix B, we provide the description of a Standard Cartesian Coordinate Space instance which applies to many Astronomical cases, and may be referenced in serializations.
   */
  export type CartesianCoordSpace = {
@@ -64,6 +85,15 @@
  };
  
  export type FileUpload = Record<string, any>;
+@@ -563,7 +568,7 @@
+   xmlId?: string;
+ };
+ 
+-export type InstrumentKind = "CONTINUUM" | "SPECTROSCOPIC";
++export type InstrumentKind = "continuum" | "spectroscopic";
+ 
+ /**
+  * an integer identifier that can be used as a key for lookup of an entity that is *outside this datamodel*
 @@ -684,6 +689,7 @@
  export type ObsType = "TargetObservation" | "CalibrationObservation";
  
@@ -72,7 +102,17 @@
    /**
     * any constraints on the observation
     */
-@@ -772,6 +778,7 @@
+@@ -706,6 +712,9 @@
+  * An organisation that can perform astronomical observations
+  */
+ export type Observatory = {
++  "@type"?: string;
++  "_id"?: number;
++
+   xmlId?: string;
+   /**
+    * The name of the organization
+@@ -772,6 +781,7 @@
   * a complete proposal
   */
  export type ObservingProposal = {
@@ -80,7 +120,7 @@
    /**
     * the proposal title
     */
-@@ -829,6 +836,8 @@
+@@ -829,6 +839,8 @@
   * An institution that is a collection of people
   */
  export type Organization = {
@@ -89,7 +129,25 @@
    /**
     * The name of the organization
     */
-@@ -1207,6 +1216,7 @@
+@@ -1053,6 +1065,8 @@
+  * Defines collection of resources and proposals for a particular observing season
+  */
+ export type ProposalCycle = {
++  _id?: number
++
+   /**
+    * a human readable description of the cycle
+    */
+@@ -1119,7 +1133,7 @@
+   observationSessionEnd?: Date;
+ };
+ 
+-export type ProposalKind = "STANDARD" | "TOO" | "SURVEY";
++export type ProposalKind = "Standard" | "ToO" | "Survey";
+ 
+ /**
+  * A review of a proposal
+@@ -1207,6 +1221,7 @@
   * A real value with a unit.
   */
  export type RealQuantity = {
@@ -97,7 +155,7 @@
    /**
     * Must conform to definition of unit in VOUnit spec.
     */
-@@ -1354,6 +1364,8 @@
+@@ -1354,6 +1369,8 @@
    /**
     * Science oriented definition of a spectral window.
     */
@@ -106,7 +164,7 @@
    spectralWindowSetup?: SpectralWindowSetup;
    expectedSpectralLine?: ExpectedSpectralLine[];
  };
-@@ -1398,6 +1410,7 @@
+@@ -1398,6 +1415,7 @@
   * A SpaceFrame is specified by its reference frame (orientation), and a reference position (origin). Currently only standard reference frames are allowed. An equinox MUST be provided for pre-ICRS reference frames. A planetary ephemeris MAY be provided if relevant. If needed, but not provided, it is assumed to be 'DE405'.
   */
  export type SpaceFrame = {
@@ -114,7 +172,7 @@
    /**
     * RefLocation defines the origin of the spatial coordinate space. This location is represented either by a standard reference position (for which the absolute location in phase space is known by definition), or a specified point in another Spatial frame. This object is used as the origin of the SpaceFrame here, but also to specify the Spatial Reference Position (refPosition) associated with other domain Frames. For example, in the Time domain, the Spatial Reference Position indicates that the 'time' values are the time that the 'event' occured at that location, which might be different from the detector location.
     */
-@@ -1420,6 +1433,7 @@
+@@ -1420,6 +1438,7 @@
   * Specialized coordinate system for the Spatial domain. This object SHOULD include an appropriate SpaceFrame. In Appendix B, we define two standard spatial coordinate space instances (Spherical and Cartesian), which may be referenced in serializations. If a CoordSpace is not provided, it is assumed to be represented by a Standard Spherical Coordinate Space.
   */
  export type SpaceSys = {
@@ -122,7 +180,7 @@
    xmlId?: string;
    /**
     * Abstract head of coordinate spaces related to physical properties.
-@@ -1503,7 +1517,7 @@
+@@ -1503,7 +1522,7 @@
    /**
     * person connected with the proposal
     */
@@ -131,7 +189,14 @@
    uid?: string;
    inKeycloakRealm?: boolean;
  };
-@@ -1559,11 +1573,13 @@
+@@ -1553,17 +1572,19 @@
+ /**
+  * A role within the timeAllocation committee
+  */
+-export type TacRole = "TECHNICALREVIEWER" | "SCIENCEREVIEWER" | "CHAIR";
++export type TacRole = "TechnicalReviewer" | "ScienceReviewer" | "Chair";
+ 
+ /**
   * A target source
   */
  export type Target = {
@@ -145,7 +210,7 @@
  };
  
  /**
-@@ -1578,6 +1594,7 @@
+@@ -1578,6 +1599,7 @@
   * an observation of the scientific target
   */
  export type TargetObservation = {
@@ -153,7 +218,7 @@
    /**
     * any constraints on the observation
     */
-@@ -1605,6 +1622,7 @@
+@@ -1605,6 +1627,7 @@
     */
    performance?: PerformanceParameters;
    spectrum?: ScienceSpectralWindow[];
@@ -161,7 +226,16 @@
    xmlId?: string;
  };
  
-@@ -1708,6 +1726,10 @@
+@@ -1645,7 +1668,7 @@
+ /**
+  * acceptable text formats for document submission
+  */
+-export type TextFormats = "LATEX" | "RST" | "ASCIIDOC";
++export type TextFormats = "latex" | "rst" | "asciidoc";
+ 
+ /**
+  * A TimeFrame SHALL include a time scale and reference position. It MAY also include a reference direction.
+@@ -1708,6 +1731,10 @@
   * particular time range
   */
  export type TimingWindow = {

--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -60,6 +60,16 @@ import AdminPanel from "./admin/adminPanel";
 import JustificationsPanel from "./ProposalEditorView/justifications/JustificationsPanel";
 import {ProposalList} from "./ProposalList";
 import ProposalManagerStartPage from "./ProposalManagerView/startPage.tsx";
+import CycleOverviewPanel from "./ProposalManagerView/proposalCycle/overview.tsx";
+import CycleDatesPanel from "./ProposalManagerView/proposalCycle/dates.tsx";
+import CycleObservingModesPanel from "./ProposalManagerView/observingModes/observingModesPanel.tsx";
+import CycleAvailableResourcesPanel from "./ProposalManagerView/availableResources/availableResourcesPanel.tsx";
+import CyclePossibleGradesPanel from "./ProposalManagerView/proposalCycle/possibleGrades.tsx";
+import CycleReviewsPanel from "./ProposalManagerView/reviews/reviewsPanel.tsx";
+import CycleAllocationsPanel from "./ProposalManagerView/allocations/allocationsPanel.tsx";
+import CycleObservatoryPanel from "./ProposalManagerView/proposalCycle/observatory.tsx";
+import CycleTACPanel from "./ProposalManagerView/TAC/tacPanel.tsx";
+import CycleTitlePanel from "./ProposalManagerView/proposalCycle/title.tsx";
 
 /**
  * defines the user context type.
@@ -124,7 +134,47 @@ function App2(): ReactElement {
                 path: "/manager",
                 element: <PSTManager />,
                 children: [
-                    {index: true, element: <PSTManagerStart />}
+                    {index: true, element: <PSTManagerStart />},
+                    {
+                        path: "cycle/:selectedCycleCode",
+                        element: <CycleOverviewPanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/title",
+                        element: <CycleTitlePanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/tac",
+                        element: <CycleTACPanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/dates",
+                        element: <CycleDatesPanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/observingModes",
+                        element: <CycleObservingModesPanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/availableResources",
+                        element: <CycleAvailableResourcesPanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/possibleGrades",
+                        element: <CyclePossibleGradesPanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/reviews",
+                        element: <CycleReviewsPanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/allocations",
+                        element: <CycleAllocationsPanel />
+                    },
+                    {
+                        path: "cycle/:selectedCycleCode/observatory",
+                        element: <CycleObservatoryPanel />
+                    }
                 ]
             },
             {

--- a/src/main/webui/src/ProposalManagerView/TAC/CommitteeMembers.tsx
+++ b/src/main/webui/src/ProposalManagerView/TAC/CommitteeMembers.tsx
@@ -1,1 +1,0 @@
-// empty file - needs content

--- a/src/main/webui/src/ProposalManagerView/TAC/tacPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/TAC/tacPanel.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CycleTACPanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit the time-allocation-committee</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/allocations/allocationsPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/allocations/allocationsPanel.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CycleAllocationsPanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit the allocation of reviewed proposals</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/availableResources/availableResourcesPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/availableResources/availableResourcesPanel.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CycleAvailableResourcesPanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit available resources for the proposal cycle</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/cycleList.tsx
+++ b/src/main/webui/src/ProposalManagerView/cycleList.tsx
@@ -1,43 +1,138 @@
-import {ReactElement} from "react";
-import {Accordion, Group} from "@mantine/core";
-import {IconBike} from "@tabler/icons-react";
+import {ReactElement, useState} from "react";
+import {Accordion, Group, NavLink} from "@mantine/core";
+import {
+    IconBike,
+    IconCalendar, IconEgg, IconLetterA,
+    IconLetterG, IconLetterO, IconLetterR,
+    IconLetterT,
+    IconTeapot,
+    IconUfo,
+    IconUsersGroup
+} from "@tabler/icons-react";
+import {useProposalCyclesResourceGetProposalCycles} from "src/generated/proposalToolComponents.ts";
+import {ObjectIdentifier} from "src/generated/proposalToolSchemas.ts";
+import {Link} from "react-router-dom";
 
 export default function CycleList() : ReactElement {
+
+    //FIXME: use an actual query
+
+    const cycles = useProposalCyclesResourceGetProposalCycles(
+        {queryParams: {includeClosed: true}}
+    )
+
+    const [accordionValue, setAccordionValue]
+        = useState<string | null>(null);
+
+
+    const cyclesList = cycles.data?.map((cycle) => {
+        return <CycleItem key={cycle.dbid} cycle={cycle} />
+    })
+
     return (
-        <Accordion>
-            <Accordion.Item value={"cycle1"} key={"cycle1"}>
-                <Accordion.Control>
-                    <Group>
-                        <IconBike />
-                        Cycle 1
-                    </Group>
-                </Accordion.Control>
-                <Accordion.Panel>
-                    Nav links to the bits of Cycle 1
-                </Accordion.Panel>
-            </Accordion.Item>
-            <Accordion.Item value={"cycle2"} key={"cycle2"}>
-                <Accordion.Control>
-                    <Group>
-                        <IconBike />
-                        Cycle 2
-                    </Group>
-                </Accordion.Control>
-                <Accordion.Panel>
-                    Nav links to the bits of Cycle 2
-                </Accordion.Panel>
-            </Accordion.Item>
-            <Accordion.Item value={"etc"} key={"etc"}>
-                <Accordion.Control>
-                    <Group>
-                        <IconBike />
-                        and so on
-                    </Group>
-                </Accordion.Control>
-                <Accordion.Panel>
-                    ...
-                </Accordion.Panel>
-            </Accordion.Item>
+        <Accordion value={accordionValue}
+                   onChange={setAccordionValue}
+                   variant={"filled"}
+        >
+            {cyclesList}
         </Accordion>
+    )
+}
+
+function CycleItem(props:{cycle: ObjectIdentifier}): ReactElement {
+    const cycle = props.cycle;
+    const [active, setActive] = useState("");
+
+    return (
+        <Accordion.Item value={String(cycle.dbid)}>
+            <Accordion.Control>
+                <Group>
+                    <IconBike/>
+                    {cycle.name}
+                </Group>
+            </Accordion.Control>
+            <Accordion.Panel>
+                <NavLink to={"cycle/" + cycle.dbid}
+                         component={Link}
+                         key={"Overview"}
+                         label={"Overview"}
+                         leftSection={<IconUfo/>}
+                         active={"Overview" + cycle.code === active}
+                         onClick={()=>setActive("Overview" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/title"}
+                         component={Link}
+                         key={"Title"}
+                         label={"Title"}
+                         leftSection={<IconLetterT/>}
+                         active={"Title" + cycle.code === active}
+                         onClick={()=>setActive("Title" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/possibleGrades"}
+                         component={Link}
+                         key={"Grades"}
+                         label={"Grades"}
+                         leftSection={<IconLetterG/>}
+                         active={"Grades" + cycle.code === active}
+                         onClick={()=>setActive("Grades" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/dates"}
+                         component={Link}
+                         key={"Dates"}
+                         label={"Dates"}
+                         leftSection={<IconCalendar/>}
+                         active={"Dates" + cycle.code === active}
+                         onClick={()=>setActive("Dates" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/observatory"}
+                         component={Link}
+                         key={"Observatory"}
+                         label={"Observatory"}
+                         leftSection={<IconTeapot/>}
+                         active={"Observatory" + cycle.code === active}
+                         onClick={()=>setActive("Observatory" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/tac"}
+                         component={Link}
+                         key={"TAC"}
+                         label={"TAC"}
+                         leftSection={<IconUsersGroup/>}
+                         active={"TAC" + cycle.code === active}
+                         onClick={()=>setActive("TAC" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/availableResources"}
+                         component={Link}
+                         key={"AvailableResources"}
+                         label={"Available Resources"}
+                         leftSection={<IconEgg/>}
+                         active={"AvailableResources" + cycle.code === active}
+                         onClick={()=>setActive("AvailableResources" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/observingModes"}
+                         component={Link}
+                         key={"ObservingModes"}
+                         label={"Observing Modes"}
+                         leftSection={<IconLetterO/>}
+                         active={"ObservingModes" + cycle.code === active}
+                         onClick={()=>setActive("ObservingModes" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/reviews"}
+                         component={Link}
+                         key={"Reviews"}
+                         label={"Reviews"}
+                         leftSection={<IconLetterR/>}
+                         active={"Reviews" + cycle.code === active}
+                         onClick={()=>setActive("Reviews" + cycle.code)}
+                />
+                <NavLink to={"cycle/" + cycle.dbid + "/allocations"}
+                         component={Link}
+                         key={"Allocations"}
+                         label={"Allocations"}
+                         leftSection={<IconLetterA/>}
+                         active={"Allocations" + cycle.code === active}
+                         onClick={()=>setActive("Allocations" + cycle.code)}
+                />
+            </Accordion.Panel>
+        </Accordion.Item>
     )
 }

--- a/src/main/webui/src/ProposalManagerView/observingModes/observingModesPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/observingModes/observingModesPanel.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CycleObservingModesPanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit the observing modes of a cycle</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle.new.form.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle.new.form.tsx
@@ -1,0 +1,123 @@
+import {ReactElement, useEffect, useState} from "react";
+import {SubmitButton} from "../commonButtons/save.tsx";
+import {useForm} from "@mantine/form";
+import {ObjectIdentifier} from "../generated/proposalToolSchemas.ts";
+import {Select, Text, TextInput} from "@mantine/core";
+import {MAX_CHARS_FOR_INPUTS} from "../constants.tsx";
+import MaxCharsForInputRemaining from "../commonInputs/remainingCharacterCount.tsx";
+import {DatesProvider, DateTimePicker} from "@mantine/dates";
+import {fetchObservatoryResourceGetObservatories} from "../generated/proposalToolComponents.ts";
+import {notifications} from "@mantine/notifications";
+import getErrorMessage from "../errorHandling/getErrorMessage.tsx";
+
+interface NewCycleFormProps {
+    closeModal?: () => void
+}
+
+export default function NewCycleForm({closeModal}: NewCycleFormProps): ReactElement {
+
+    interface NewCycleFormType {
+        title: string,
+        submissionDeadline: Date | null,
+        sessionStart: Date | null,
+        sessionEnd: Date | null,
+        observatoryId: number | undefined
+    }
+
+    const [observatories, setObservatories]
+        = useState<{ value: string, label: string }[]>([]);
+
+    useEffect(() => {
+        fetchObservatoryResourceGetObservatories({})
+            .then((data: ObjectIdentifier[]) => {
+                setObservatories(
+                    data?.map((obs) => (
+                        {value: String(obs.dbid), label: obs.name!}
+                    ))
+                );
+            })
+            .catch((error) => {
+                notifications.show({
+                    autoClose: false,
+                    title: "Loading Observatories failed",
+                    message: "Cannot load Observatories, caused by " + getErrorMessage(error)
+                });
+            });
+
+    }, []);
+
+
+    const form = useForm<NewCycleFormType>(
+        {
+            initialValues: {
+                title: "",
+                submissionDeadline: null,
+                sessionStart: null,
+                sessionEnd: null,
+                observatoryId: undefined
+            },
+
+            validate: {
+                title:
+                    value => (value.length < 3 ? 'Title must have at least 3 characters' : null),
+                submissionDeadline:
+                    value => (value === null ? 'Please select a submission deadline date' : null),
+                sessionStart:
+                    value => (value === null ? 'Please select an observation session start date' : null),
+                sessionEnd:
+                    value => (value === null ? 'Please select an observation session end date' : null),
+                observatoryId:
+                    value => (value === undefined ? 'Please select an observatory' : null)
+            }
+        }
+    );
+
+    function createCycle(values: NewCycleFormType) {
+        //we will have to convert dates to number of seconds since posix epoch
+        console.log(values);
+
+        closeModal && closeModal();
+    }
+
+    return (
+        <form onSubmit={form.onSubmit((values) => createCycle(values))}>
+            <SubmitButton toolTipLabel={"save a new proposal cycle"}
+                          disabled={!form.isValid()}
+            />
+            <DatesProvider settings={{timezone: 'UTC'}}>
+                <TextInput
+                    name={"title"}
+                    maxLength={MAX_CHARS_FOR_INPUTS}
+                    placeholder={"Proposal Cycle title"}
+                    label={"Title"}
+                    {...form.getInputProps('title')}
+                />
+                <MaxCharsForInputRemaining length={form.values.title.length}/>
+                <DateTimePicker
+                    placeholder={"submission deadline"}
+                    minDate={new Date()}
+                    rightSection={<Text>submission deadline</Text>}
+                    {...form.getInputProps('submissionDeadline')}
+                />
+                <DateTimePicker
+                    placeholder={"session start"}
+                    minDate={new Date()}
+                    rightSection={<Text>session start</Text>}
+                    {...form.getInputProps('sessionStart')}
+                />
+                <DateTimePicker
+                    placeholder={"session end"}
+                    minDate={new Date()}
+                    rightSection={<Text>session end</Text>}
+                    {...form.getInputProps('sessionEnd')}
+                />
+                <Select
+                    label={"Observatory"}
+                    placeholder={"pick one"}
+                    data={observatories}
+                    {...form.getInputProps('observatoryId')}
+                />
+            </DatesProvider>
+        </form>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/Overview.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/Overview.tsx
@@ -1,1 +1,0 @@
-// empty file - needs content

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/dates.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/dates.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CycleDatesPanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit proposal cycle dates</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/observatory.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/observatory.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CycleObservatoryPanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit the observatory used for the cycle</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/overview.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/overview.tsx
@@ -1,0 +1,86 @@
+import {ReactElement} from "react";
+import {Box, Container, Divider, Group, Stack, Text} from "@mantine/core";
+import {
+    useProposalCyclesResourceGetProposalCycle
+} from "../../generated/proposalToolComponents.ts";
+import {useParams} from "react-router-dom";
+import {JSON_SPACES} from "../../constants.tsx";
+
+
+//ASSUMES input string is ISO date-time at GMT+0
+function prettyDateTime(input : string ) : string {
+    const dateTime : string[] = input.split('T');
+    const date = dateTime[0];
+    const timeFrac = dateTime[1];
+
+    const time = timeFrac.split('.')[0];
+
+    return date + " " + time + " GMT";
+}
+
+
+export default function CycleOverviewPanel() : ReactElement {
+
+    const {selectedCycleCode} = useParams();
+
+    const cycle = useProposalCyclesResourceGetProposalCycle(
+        {pathParams: {cycleCode: Number(selectedCycleCode)}}
+    )
+
+    if (cycle.error) {
+        return (
+            <Box>
+                <pre>{JSON.stringify(cycle.error, null, JSON_SPACES)}</pre>
+            </Box>
+        );
+    }
+
+    const DisplayTitle = () : ReactElement => {
+        return(
+            <h1>{cycle.data?.title}</h1>
+        )
+    }
+
+    const DisplayDates = () : ReactElement => {
+        return (
+            <Stack>
+                <h3>Important Dates</h3>
+                <Group grow>
+                <Text>Submission deadline:</Text>
+                    {
+                        cycle.data?.submissionDeadline &&
+                        <Text c={"orange"}> {prettyDateTime(cycle.data.submissionDeadline)}</Text>
+                    }
+                </Group>
+                <Divider />
+                <Group grow>
+                    <Text>Observation session start:</Text>
+                    {
+                        cycle.data?.observationSessionStart &&
+                        <Text c={"orange"}>{prettyDateTime(cycle.data.observationSessionStart)}</Text>
+                    }
+                </Group>
+                <Divider />
+                <Group grow>
+                    <Text>Observation session end:</Text>
+                    {
+                        cycle.data?.observationSessionEnd &&
+                        <Text c={"orange"}>{prettyDateTime(cycle.data.observationSessionEnd)}</Text>
+                    }
+                </Group>
+            </Stack>
+
+        )
+    }
+
+
+    return (
+        <Container fluid>
+            <DisplayTitle />
+            <DisplayDates />
+            {
+                //ToDo: display functions for other fields of a proposal cycle e.g., tac members, resources,...
+            }
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/possibleGrades.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/possibleGrades.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CyclePossibleGradesPanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit the possible grades of a proposal cycle</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/title.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/title.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CycleTitlePanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit the proposal cycle title</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/reviewers/List.tsx
+++ b/src/main/webui/src/ProposalManagerView/reviewers/List.tsx
@@ -1,1 +1,0 @@
-// empty file - needs content

--- a/src/main/webui/src/ProposalManagerView/reviews/reviewsPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/reviews/reviewsPanel.tsx
@@ -1,0 +1,10 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default function CycleReviewsPanel() : ReactElement {
+    return (
+        <Container fluid>
+            <Text>WIP: this is where you view/edit reviews of submitted proposals</Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/startPage.tsx
+++ b/src/main/webui/src/ProposalManagerView/startPage.tsx
@@ -4,7 +4,7 @@ import {
     AppShell,
     Burger, Checkbox, Container,
     Grid,
-    Group, ScrollArea,
+    Group, Modal, ScrollArea,
     Tooltip, useMantineColorScheme, useMantineTheme
 } from "@mantine/core";
 import {
@@ -19,12 +19,16 @@ import {Outlet, useNavigate} from "react-router-dom";
 import {ColourSchemeToggle} from "../ColourSchemeToggle.tsx";
 import {useDisclosure} from "@mantine/hooks";
 import CycleList from "./cycleList.tsx";
+import AddButton from "../commonButtons/add.tsx";
+import NewCycleForm from "./proposalCycle.new.form.tsx";
 
 export default function ProposalManagerStartPage() : ReactElement {
     const navigate = useNavigate();
     const [opened, {toggle}] = useDisclosure();
     const theme = useMantineTheme();
     const {colorScheme} = useMantineColorScheme();
+
+    const [modalOpened, {close, open}] = useDisclosure();
 
     return (
         <AppShell
@@ -65,6 +69,18 @@ export default function ProposalManagerStartPage() : ReactElement {
                                     <IconLicense />
                                 </ActionIcon>
                             </Tooltip>
+                            <AddButton toolTipLabel={"new proposal cycle"}
+                                       label={"Create a new Proposal Cycle"}
+                                       onClick={open}
+                            />
+                            <Modal
+                                opened={modalOpened}
+                                onClose={close}
+                                title={"New Proposal Cycle"}
+                                fullScreen
+                            >
+                                <NewCycleForm closeModal={close}/>
+                            </Modal>
                         </Group>
                     </Grid.Col>
                     <Grid.Col span={1}>

--- a/src/main/webui/src/ProposalManagerView/startPage.tsx
+++ b/src/main/webui/src/ProposalManagerView/startPage.tsx
@@ -76,8 +76,9 @@ export default function ProposalManagerStartPage() : ReactElement {
                             <Modal
                                 opened={modalOpened}
                                 onClose={close}
-                                title={"New Proposal Cycle"}
-                                fullScreen
+                                title={"New Proposal Cycle Form"}
+                                size={"40%"}
+                                closeOnClickOutside={false}
                             >
                                 <NewCycleForm closeModal={close}/>
                             </Modal>
@@ -128,6 +129,5 @@ export default function ProposalManagerStartPage() : ReactElement {
                 <Outlet/>
             </AppShell.Main>
         </AppShell>
-
     )
 }

--- a/src/main/webui/src/ProposalManagerView/startPage.tsx
+++ b/src/main/webui/src/ProposalManagerView/startPage.tsx
@@ -82,8 +82,6 @@ export default function ProposalManagerStartPage() : ReactElement {
                                     <IconLogout size={ICON_SIZE}/>
                                 </ActionIcon>
                             </Tooltip>
-
-
                         </Group>
                     </Grid.Col>
                 </Grid>

--- a/src/main/webui/src/generated/proposalToolSchemas.ts
+++ b/src/main/webui/src/generated/proposalToolSchemas.ts
@@ -712,6 +712,9 @@ export type Observation = {
  * An organisation that can perform astronomical observations
  */
 export type Observatory = {
+  "@type"?: string;
+  "_id"?: number;
+
   xmlId?: string;
   /**
    * The name of the organization
@@ -1062,6 +1065,8 @@ export type Polygon = {
  * Defines collection of resources and proposals for a particular observing season
  */
 export type ProposalCycle = {
+  _id?: number
+
   /**
    * a human readable description of the cycle
    */


### PR DESCRIPTION
- Lists all ProposalCycles in the data base, and provides Navlinks to various sub-fields of a Cycle (content is mostly placeholder stuff)
- Added ability to create a new proposal cycle with the minimum amount of data. 
- updated proposalSchemas reflecting a change in the underlying data model, and to add missing fields for ProposalCycles and Observatories (patch file also updated).