### PR TITLE
135 standardise panel titles

### DIFF
--- a/src/main/webui/src/ProposalEditorView/Investigators/List.tsx
+++ b/src/main/webui/src/ProposalEditorView/Investigators/List.tsx
@@ -12,6 +12,7 @@ import {randomId} from "@mantine/hooks";
 import DeleteButton from "src/commonButtons/delete";
 import AddButton from "src/commonButtons/add";
 import { JSON_SPACES } from 'src/constants.tsx';
+import {EditorPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 /**
  * the data associated with a given person.
@@ -54,7 +55,7 @@ function InvestigatorsPanel(): ReactElement {
 
     return (
         <Box>
-            <Text fz="lg" fw={700}>Investigators linked to this proposal</Text>
+            <EditorPanelTitle proposalCode={Number(selectedProposalCode)} panelTitle={"Investigators"}/>
             <Grid>
                 <Grid.Col span={5}>
                 <AddButton toolTipLabel={"Add new"}

--- a/src/main/webui/src/ProposalEditorView/Investigators/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/Investigators/New.tsx
@@ -114,7 +114,7 @@ function AddInvestigatorPanel(): ReactElement {
                         {...form.getInputProps("selectedInvestigator")}
                     />
                     <Grid>
-                        <Grid.Col span={1}>
+                        <Grid.Col span={2}>
                             <SubmitButton
                                 label={"Add"}
                                 toolTipLabel={"Add new investigator"}/>

--- a/src/main/webui/src/ProposalEditorView/Investigators/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/Investigators/New.tsx
@@ -12,6 +12,7 @@ import {useForm} from "@mantine/form";
 import {SubmitButton} from "src/commonButtons/save";
 import DeleteButton from "src/commonButtons/delete";
 import { JSON_SPACES } from 'src/constants.tsx';
+import {EditorPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 /**
  * Render s form panel to add an investigator to the current proposal.
@@ -96,7 +97,7 @@ function AddInvestigatorPanel(): ReactElement {
 
     return (
             <Box>
-                <h3>Add an investigator</h3>
+                <EditorPanelTitle proposalCode={Number(selectedProposalCode)} panelTitle={"Add an investigator"} />
                 <form onSubmit={handleAdd}>
                     <Select label={"Type"}
                         data={typeData}

--- a/src/main/webui/src/ProposalEditorView/justifications/JustificationsPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/JustificationsPanel.tsx
@@ -1,13 +1,13 @@
 import {ReactElement} from "react";
-import {Badge, Box, Container, Title} from "@mantine/core";
+import {Box, Container} from "@mantine/core";
 import {useParams} from "react-router-dom";
 import {
     useProposalResourceGetJustification,
-    useProposalResourceGetObservingProposalTitle
 } from "src/generated/proposalToolComponents.ts";
 import {JSON_SPACES} from "src/constants.tsx";
 import {Justification} from "src/generated/proposalToolSchemas.ts";
 import JustificationsTable from "./justifications.table.tsx";
+import {EditorPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 //no need to use an array, only two "kinds" of Justification 'scientific' and 'technical'
 export type JustificationKinds = {
@@ -18,14 +18,6 @@ export type JustificationKinds = {
 export default function JustificationsPanel() : ReactElement {
 
     const { selectedProposalCode } = useParams();
-
-    const {
-        data: title,
-        error: titleError,
-        isLoading: titleIsLoading
-    } = useProposalResourceGetObservingProposalTitle(
-        {pathParams: {proposalCode: Number(selectedProposalCode)}}
-    )
 
     const {
         data : scientific,
@@ -42,14 +34,6 @@ export default function JustificationsPanel() : ReactElement {
     } = useProposalResourceGetJustification(
         { pathParams: { proposalCode: Number(selectedProposalCode), which: "technical" } }
     );
-
-    if (titleError) {
-        return (
-            <Box>
-                <pre>{JSON.stringify(scientificError, null, JSON_SPACES)}</pre>
-            </Box>
-        );
-    }
 
 
     if (scientificError) {
@@ -70,12 +54,7 @@ export default function JustificationsPanel() : ReactElement {
 
     return (
         <Container fluid>
-            <Title order={3}>
-                { titleIsLoading ?
-                    <Badge size={"xl"} radius={0}>...</Badge> :
-                    <Badge size={"xl"} radius={0}>{title}</Badge>
-                } : Justifications
-            </Title>
+            <EditorPanelTitle proposalCode={Number(selectedProposalCode)} panelTitle={"Justifications"} />
 
             {scientificIsLoading || technicalIsLoading ? (`Loading justifications...`) :
                 <JustificationsTable scientific={scientific!} technical={technical!} />

--- a/src/main/webui/src/ProposalEditorView/observations/observationPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/observationPanel.tsx
@@ -1,18 +1,18 @@
 import {
     useObservationResourceGetObservations,
-    useProposalResourceGetObservingProposalTitle,
     useProposalResourceGetTargets,
     useTechnicalGoalResourceGetTechnicalGoals,
 } from 'src/generated/proposalToolComponents';
 import {useParams} from "react-router-dom";
 import ObservationRow, { observationTableHeader } from './observationTable.tsx';
-import {Badge, Container, Group, Space, Table, Title} from "@mantine/core";
+import {Container, Group, Space, Table} from "@mantine/core";
 import {Observation} from "src/generated/proposalToolSchemas.ts";
 import getErrorMessage from "src/errorHandling/getErrorMessage.tsx";
 import { ReactElement } from 'react';
 import ObservationEditModal from './edit.modal.tsx';
 import NavigationButton from 'src/commonButtons/navigation.tsx';
 import { IconTarget, IconChartLine } from '@tabler/icons-react';
+import {EditorPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 
 /**
@@ -74,12 +74,6 @@ function Observations() {
             {enabled: true}
         );
 
-    // get the title of the proposal.
-    const {data: titleData, error: titleError, isLoading: titleLoading} =
-        useProposalResourceGetObservingProposalTitle(
-            {pathParams: {proposalCode: Number(selectedProposalCode)}}
-        );
-
     /**
      * generates the top header part of the panel.
      *
@@ -88,13 +82,7 @@ function Observations() {
      */
     const Header = (): ReactElement => {
         return (
-            <Title order={3}>
-                { titleLoading ?
-                    <Badge size={"xl"} radius={0}>...</Badge> :
-                    <Badge size={"xl"} radius={0}>{titleData}</Badge>
-                }
-                : Observations
-            </Title>
+            <EditorPanelTitle proposalCode={Number(selectedProposalCode)} panelTitle={"Observations"} />
         )
     }
 
@@ -160,7 +148,7 @@ function Observations() {
     // process any errors.
     const possibleErrors: (
         {status: "unknown", payload: string} | null | undefined) [] = [
-            observationsError, targetsError, titleError, technicalGoalError];
+            observationsError, targetsError, technicalGoalError];
     const filtered: {status: "unknown", payload: string}[] =
         possibleErrors.flatMap(f => f ? [f] : []);
     if (filtered.length !== 0) {

--- a/src/main/webui/src/ProposalEditorView/proposal/Documents.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Documents.tsx
@@ -18,6 +18,7 @@ import {
     DownloadRequestButton
 } from 'src/commonButtons/download.tsx';
 import {HEADER_FONT_WEIGHT, JSON_SPACES, MAX_SUPPORTING_DOCUMENT_SIZE} from 'src/constants.tsx';
+import {EditorPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 type DocumentProps = {
     dbid: number,
@@ -98,10 +99,7 @@ const DocumentsPanel = () => {
 
     return (
         <Box>
-            <Text fz="lg"
-                  fw={HEADER_FONT_WEIGHT}>
-                View and retrieve documents
-            </Text>
+            <EditorPanelTitle proposalCode={Number(selectedProposalCode)} panelTitle={"Documents"} />
             <Box>
                 <Table>
                     <Table.Tbody>

--- a/src/main/webui/src/ProposalEditorView/proposal/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/New.tsx
@@ -18,6 +18,7 @@ import {useQueryClient} from "@tanstack/react-query";
 import { SubmitButton } from 'src/commonButtons/save';
 import { MAX_CHARS_FOR_INPUTS, TEXTAREA_MAX_ROWS } from "src/constants";
 import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.tsx";
+import {PanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 
 const kindData = [
@@ -94,7 +95,7 @@ const textFormatData = [
 
      return (
         <Box>
-            <Text fz="lg" fw={700}>Create Proposal</Text>
+            <PanelTitle itemName={"NEW"} panelTitle={"Create Proposal"} />
             {submitting &&
                 <Box>Submitting request</Box>
             }

--- a/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
@@ -13,6 +13,7 @@ import {SubmitButton} from "src/commonButtons/save.tsx";
 import {useQueryClient} from "@tanstack/react-query";
 import {notifications} from "@mantine/notifications";
 import ValidationOverview from "./ValidationOverview.tsx";
+import {EditorPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 function SubmitPanel(): ReactElement {
     const {selectedProposalCode} = useParams();
@@ -94,7 +95,7 @@ function SubmitPanel(): ReactElement {
 
     return (
         <Box>
-            <Text fz="lg" fw={700}>Submit Proposal</Text>
+            <EditorPanelTitle proposalCode={Number(selectedProposalCode)} panelTitle={"Submit"} />
 
             <ValidationOverview cycle={selectedCycle}/>
 

--- a/src/main/webui/src/ProposalEditorView/proposal/Summary.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Summary.tsx
@@ -6,11 +6,10 @@ import {
 } from "src/generated/proposalToolComponents";
 import {useMutation, useQueryClient} from "@tanstack/react-query";
 import {useParams} from "react-router-dom";
-import {Box, Text, Textarea} from "@mantine/core";
+import {Box, Textarea} from "@mantine/core";
 import {useForm} from "@mantine/form";
 import { SubmitButton } from 'src/commonButtons/save';
 import {
-    HEADER_FONT_WEIGHT,
     JSON_SPACES,
     MAX_CHARS_FOR_INPUTS, TEXTAREA_MAX_ROWS
 } from 'src/constants';

--- a/src/main/webui/src/ProposalEditorView/proposal/Summary.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Summary.tsx
@@ -15,6 +15,7 @@ import {
     MAX_CHARS_FOR_INPUTS, TEXTAREA_MAX_ROWS
 } from 'src/constants';
 import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.tsx";
+import {PanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 function SummaryPanel() {
     const { selectedProposalCode } = useParams();
@@ -82,7 +83,7 @@ function SummaryPanel() {
 
     return (
         <Box>
-            <Text fz="lg" fw={HEADER_FONT_WEIGHT}>Update summary</Text>
+            <PanelTitle isLoading={isLoading} itemName={data?.title as string} panelTitle={"Summary"} />
             {isLoading ? <Box>loading...</Box>:
               submitting ?
                 <Box>Submitting request</Box> :

--- a/src/main/webui/src/ProposalEditorView/proposal/Title.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Title.tsx
@@ -5,11 +5,11 @@ import {
     useProposalResourceGetObservingProposalTitle,
 } from "src/generated/proposalToolComponents";
 import {useMutation, useQueryClient} from "@tanstack/react-query";
-import {Box, Text, TextInput} from "@mantine/core";
+import {Box, TextInput} from "@mantine/core";
 import {useParams} from "react-router-dom";
 import {useForm} from "@mantine/form";
 import { SubmitButton } from 'src/commonButtons/save';
-import { MAX_CHARS_FOR_INPUTS, HEADER_FONT_WEIGHT, JSON_SPACES } from 'src/constants';
+import { MAX_CHARS_FOR_INPUTS, JSON_SPACES } from 'src/constants';
 import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.tsx";
 import {PanelTitle} from "../../commonPanelFeatures/title.tsx";
 

--- a/src/main/webui/src/ProposalEditorView/proposal/Title.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Title.tsx
@@ -11,6 +11,7 @@ import {useForm} from "@mantine/form";
 import { SubmitButton } from 'src/commonButtons/save';
 import { MAX_CHARS_FOR_INPUTS, HEADER_FONT_WEIGHT, JSON_SPACES } from 'src/constants';
 import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.tsx";
+import {PanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 const titleFormJSON =  {
     initialValues: {title: "Loading..."},
@@ -82,7 +83,7 @@ function TitlePanel() {
 
     return (
         <Box>
-            <Text fz="lg" fw={HEADER_FONT_WEIGHT}>Update title</Text>
+            <PanelTitle isLoading={isLoading} itemName={data as unknown as string} panelTitle={"Title"} />
             { isLoading ? ("Loading..") :
                  submitting ? ("Submitting..."):
             <form onSubmit={updateTitle}>

--- a/src/main/webui/src/ProposalEditorView/proposal/ValidationOverview.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/ValidationOverview.tsx
@@ -21,7 +21,7 @@ export default function ValidationOverview(props: {cycle: number}) {
     }
 
     return (
-        <Box m={20}>Server side validation overview
+        <Box m={20}>Validation overview
             {isLoading?(<Text>Loading...</Text>):(
                 <Table>
                     <Table.Tbody>

--- a/src/main/webui/src/ProposalEditorView/targets/targetPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/targetPanel.tsx
@@ -5,10 +5,11 @@ import {
 
 import AddTargetModal from "./New";
 import {useParams} from "react-router-dom";
-import { Box, Text } from '@mantine/core';
+import { Box } from '@mantine/core';
 import { ReactElement } from 'react';
-import { HEADER_FONT_WEIGHT, JSON_SPACES } from 'src/constants.tsx';
+import { JSON_SPACES } from 'src/constants.tsx';
 import { TargetTable } from './TargetTable.tsx';
+import {EditorPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 /**
  * Renders the target panel containing an add target button
@@ -48,10 +49,7 @@ export function TargetPanel(): ReactElement {
 
     return (
         <Box>
-            <Text fz="lg"
-                  fw={HEADER_FONT_WEIGHT}>
-                Add and edit targets
-            </Text>
+            <EditorPanelTitle proposalCode={Number(selectedProposalCode)} panelTitle={"Targets"} />
             <Box>
                 <AddTargetModal/>
                 {data?.length === 0?

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/technicalGoalsPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/technicalGoalsPanel.tsx
@@ -1,15 +1,15 @@
 import {
     useProposalResourceGetObservingProposal,
-    useProposalResourceGetObservingProposalTitle,
     useTechnicalGoalResourceGetTechnicalGoals,
 } from 'src/generated/proposalToolComponents.ts';
-import {Badge, Box, Container, Group, Space, Title} from '@mantine/core';
+import {Box, Container, Group, Space} from '@mantine/core';
 import { useParams } from 'react-router-dom';
 import {TechnicalGoalsTable } from './technicalGoalTable.tsx';
 import { TechnicalGoal } from 'src/generated/proposalToolSchemas.ts';
 import TechnicalGoalEditModal from './edit.modal.tsx';
 import { ReactElement } from 'react';
 import { JSON_SPACES } from 'src/constants.tsx';
+import {EditorPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 /**
  * the data type shared by the edit components.
@@ -48,14 +48,6 @@ function TechnicalGoalsPanel(): ReactElement {
             {pathParams: {proposalCode: Number(selectedProposalCode)},},
             {enabled: true}
         );
-    const {
-        data: titleData,
-        error: titleError,
-        isLoading: titleLoading} =
-        useProposalResourceGetObservingProposalTitle(
-            {pathParams: {proposalCode: Number(selectedProposalCode)}}
-        );
-
 
     // acquire all the bound technical ids in observations.
     let boundTechnicalGoalIds: (number | undefined)[] | undefined;
@@ -73,26 +65,11 @@ function TechnicalGoalsPanel(): ReactElement {
         );
     }
 
-    if (titleError) {
-        return (
-            <Box>
-                <pre>{JSON.stringify(titleError, null, JSON_SPACES)}</pre>
-            </Box>
-        );
-    }
-
-
     //<TechnicalGoalEditModal technicalGoal={undefined}/> is an alias for the "Add +" button,
     // the "view/edit" button is found in TechnicalGoalsTable, specifically one per row
     return (
         <Container fluid>
-            <Title order={3}>
-                {titleLoading ?
-                    <Badge size={"xl"} radius={0}>...</Badge> :
-                    <Badge size={"xl"} radius={0}>{titleData}</Badge>
-                }
-                : Technical Goals
-            </Title>
+            <EditorPanelTitle proposalCode={Number(selectedProposalCode)} panelTitle={"Technical Goals"} />
             {goalsLoading ? (`Loading...`) :
                 <TechnicalGoalsTable
                     goals={goals}

--- a/src/main/webui/src/ProposalManagerView/TAC/tacNewMember.tsx
+++ b/src/main/webui/src/ProposalManagerView/TAC/tacNewMember.tsx
@@ -11,6 +11,7 @@ import {useForm} from "@mantine/form";
 import {SubmitButton} from "src/commonButtons/save";
 import DeleteButton from "src/commonButtons/delete";
 import { JSON_SPACES } from 'src/constants.tsx';
+import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 /**
  * Renders form panel to add a reviewer to the TAC of the current cycle.
@@ -100,7 +101,7 @@ function CycleTACAddMemberPanel(): ReactElement {
 
     return (
         <Box>
-            <h3>Add an investigator</h3>
+            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Add a reviewer"} />
             <form onSubmit={handleAdd}>
                 <Select label={"Role"}
                         data={typeData}
@@ -113,7 +114,7 @@ function CycleTACAddMemberPanel(): ReactElement {
                     {...form.getInputProps("selectedMember")}
                 />
                 <Grid>
-                    <Grid.Col span={1}>
+                    <Grid.Col span={2}>
                         <SubmitButton
                             label={"Add"}
                             toolTipLabel={"Add new committee member"}/>

--- a/src/main/webui/src/ProposalManagerView/TAC/tacPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/TAC/tacPanel.tsx
@@ -12,6 +12,7 @@ import {JSON_SPACES} from "../../constants.tsx";
 import {useQueryClient} from "@tanstack/react-query";
 import {modals} from "@mantine/modals";
 import DeleteButton from "../../commonButtons/delete";
+import {ManagerPanelTitle, PanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 /**
  * the data associated with a given member.
@@ -46,7 +47,7 @@ export default function CycleTACPanel() : ReactElement {
 
     return (
         <Container fluid>
-            <Text fz={"lg"} fw={700}> Time Allocation Committee for this cycle</Text>
+            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Time Allocation Committee"}/>
             <Grid>
                 <Grid.Col span={5}>
                     <AddButton toolTipLabel={"Add new"}

--- a/src/main/webui/src/ProposalManagerView/TAC/tacPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/TAC/tacPanel.tsx
@@ -12,7 +12,7 @@ import {JSON_SPACES} from "../../constants.tsx";
 import {useQueryClient} from "@tanstack/react-query";
 import {modals} from "@mantine/modals";
 import DeleteButton from "../../commonButtons/delete";
-import {ManagerPanelTitle, PanelTitle} from "../../commonPanelFeatures/title.tsx";
+import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 /**
  * the data associated with a given member.

--- a/src/main/webui/src/ProposalManagerView/allocations/allocationsPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/allocations/allocationsPanel.tsx
@@ -1,9 +1,14 @@
 import {ReactElement} from "react";
 import {Container, Text} from "@mantine/core";
+import {useParams} from "react-router-dom";
+import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 export default function CycleAllocationsPanel() : ReactElement {
+    const {selectedCycleCode} = useParams();
+
     return (
         <Container fluid>
+            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Allocations"} />
             <Text>WIP: this is where you view/edit the allocation of reviewed proposals</Text>
         </Container>
     )

--- a/src/main/webui/src/ProposalManagerView/availableResources/availableResourcesPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/availableResources/availableResourcesPanel.tsx
@@ -1,8 +1,8 @@
 import {ReactElement} from "react";
-import {Badge, Container, Fieldset, Grid, Group, Space, Stack, Table, Text, Title} from "@mantine/core";
+import {Container, Fieldset, Grid, Group, Space, Stack, Table, Text} from "@mantine/core";
 import {
     fetchAvailableResourcesResourceRemoveCycleResource,
-    useAvailableResourcesResourceGetCycleAvailableResources, useProposalCyclesResourceGetProposalCycleDates,
+    useAvailableResourcesResourceGetCycleAvailableResources,
     useResourceTypeResourceGetAllResourceTypes
 } from "src/generated/proposalToolComponents.ts";
 import {useParams} from "react-router-dom";
@@ -14,6 +14,7 @@ import DeleteButton from "../../commonButtons/delete.tsx";
 import {modals} from "@mantine/modals";
 import {useQueryClient} from "@tanstack/react-query";
 import ResourceTypeModal from "./resourceType.modal.tsx";
+import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 
 export type AvailableResourcesProps  = {
@@ -42,14 +43,6 @@ export default function CycleAvailableResourcesPanel() : ReactElement {
     const resourceTypes =
         useResourceTypeResourceGetAllResourceTypes({});
 
-    //Cycle Dates object contains the cycle title, along with the dates
-    const cycleTitle =
-        useProposalCyclesResourceGetProposalCycleDates({
-            pathParams:{
-                cycleCode: Number(selectedCycleCode)
-            }
-        })
-
     if (availableResources.error) {
         notifications.show({
             message: "cause " + getErrorMessage(availableResources.error),
@@ -63,15 +56,6 @@ export default function CycleAvailableResourcesPanel() : ReactElement {
         notifications.show({
             message: "cause: " + getErrorMessage(resourceTypes.error),
             title: "Error loading resource types",
-            autoClose: 5000,
-            color: 'red'
-        })
-    }
-
-    if (cycleTitle.error) {
-        notifications.show({
-            message: "cause: " + getErrorMessage(cycleTitle.error),
-            title: "Error loading cycle title",
             autoClose: 5000,
             color: 'red'
         })
@@ -174,13 +158,7 @@ export default function CycleAvailableResourcesPanel() : ReactElement {
     //in this Cycle equals the total number of resource types added to the Tool.
     return (
         <Container fluid>
-            <Title order={3}>
-                {cycleTitle.isLoading ?
-                    <Badge size={"xl"} radius={0}>...</Badge> :
-                    <Badge size={"xl"} radius={0}>{cycleTitle.data?.title}</Badge>
-                }
-                : Available Resources
-            </Title>
+            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Available Resources"} />
             <Space h={"xl"}/>
             <Grid columns={10}>
                 <Grid.Col span={7}>

--- a/src/main/webui/src/ProposalManagerView/observingModes/observingModesPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/observingModes/observingModesPanel.tsx
@@ -1,9 +1,14 @@
 import {ReactElement} from "react";
 import {Container, Text} from "@mantine/core";
+import {useParams} from "react-router-dom";
+import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 export default function CycleObservingModesPanel() : ReactElement {
+    const {selectedCycleCode} = useParams();
+
     return (
         <Container fluid>
+            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Observing Modes"} />
             <Text>WIP: this is where you view/edit the observing modes of a cycle</Text>
         </Container>
     )

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/dates.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/dates.tsx
@@ -1,5 +1,5 @@
 import {ReactElement, useEffect, useState} from "react";
-import {Badge, Container, Group, Stack, Text, Title} from "@mantine/core";
+import {Container, Group, Stack, Text} from "@mantine/core";
 import {useForm} from "@mantine/form";
 import {DatesProvider, DateTimePicker} from "@mantine/dates";
 import {SubmitButton} from "../../commonButtons/save.tsx";
@@ -12,6 +12,7 @@ import {
 } from "../../generated/proposalToolComponents.ts";
 import {JSON_SPACES} from "../../constants.tsx";
 import {notifications} from "@mantine/notifications";
+import {PanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 export default function CycleDatesPanel() : ReactElement {
     interface updateDatesForm {
@@ -112,12 +113,7 @@ export default function CycleDatesPanel() : ReactElement {
 
     return (
         <Container fluid>
-            <Title order={3}>
-                { isLoading ?
-                    <Badge size={"xl"} radius={0}>...</Badge> :
-                    <Badge size={"xl"} radius={0}>{proposalCycleTitle}</Badge>
-                } : Dates
-            </Title>
+            <PanelTitle isLoading={isLoading} itemName={proposalCycleTitle} panelTitle={"Dates"}/>
 
             <form onSubmit={handleSave}>
                 <DatesProvider settings={{timezone: 'UTC'}}>

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/observatory.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/observatory.tsx
@@ -1,9 +1,14 @@
 import {ReactElement} from "react";
 import {Container, Text} from "@mantine/core";
+import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
+import {useParams} from "react-router-dom";
 
 export default function CycleObservatoryPanel() : ReactElement {
+    const {selectedCycleCode} = useParams();
+
     return (
         <Container fluid>
+            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Observatory"} />
             <Text>WIP: this is where you view/edit the observatory used for the cycle</Text>
         </Container>
     )

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/possibleGrades.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/possibleGrades.tsx
@@ -1,9 +1,14 @@
 import {ReactElement} from "react";
 import {Container, Text} from "@mantine/core";
+import {useParams} from "react-router-dom";
+import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 export default function CyclePossibleGradesPanel() : ReactElement {
+    const {selectedCycleCode} = useParams();
+
     return (
         <Container fluid>
+            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Grades"} />
             <Text>WIP: this is where you view/edit the possible grades of a proposal cycle</Text>
         </Container>
     )

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/title.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/title.tsx
@@ -1,5 +1,5 @@
 import {ReactElement, useEffect, useState} from "react";
-import {Container, Text, TextInput} from "@mantine/core";
+import {Container, TextInput} from "@mantine/core";
 import {useParams} from "react-router-dom";
 import {
     fetchProposalCyclesResourceReplaceCycleTitle,
@@ -8,9 +8,10 @@ import {
 } from "../../generated/proposalToolComponents.ts";
 import {useForm} from "@mantine/form";
 import {useMutation, useQueryClient} from "@tanstack/react-query";
-import {HEADER_FONT_WEIGHT, JSON_SPACES, MAX_CHARS_FOR_INPUTS} from "../../constants.tsx";
+import {JSON_SPACES, MAX_CHARS_FOR_INPUTS} from "../../constants.tsx";
 import MaxCharsForInputRemaining from "../../commonInputs/remainingCharacterCount.tsx";
 import {SubmitButton} from "../../commonButtons/save.tsx";
+import {PanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 const cycleTitleFormJSON =  {
     initialValues: {title: "Loading..."},
@@ -86,7 +87,7 @@ export default function CycleTitlePanel() : ReactElement {
 
     return (
         <Container fluid>
-            <Text fz="lg" fw={HEADER_FONT_WEIGHT}>Update title</Text>
+            <PanelTitle isLoading={isLoading} itemName={data as unknown as string} panelTitle={"Title"} />
             { isLoading ? ("Loading..") :
                 submitting ? ("Submitting..."):
                     <form onSubmit={updateTitle}>

--- a/src/main/webui/src/ProposalManagerView/reviews/reviewsPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/reviews/reviewsPanel.tsx
@@ -1,9 +1,14 @@
 import {ReactElement} from "react";
 import {Container, Text} from "@mantine/core";
+import {useParams} from "react-router-dom";
+import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
 
 export default function CycleReviewsPanel() : ReactElement {
+    const {selectedCycleCode} = useParams();
+
     return (
         <Container fluid>
+            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Reviews"} />
             <Text>WIP: this is where you view/edit reviews of submitted proposals</Text>
         </Container>
     )

--- a/src/main/webui/src/commonPanelFeatures/panelFeatureInterfaceProps.tsx
+++ b/src/main/webui/src/commonPanelFeatures/panelFeatureInterfaceProps.tsx
@@ -1,0 +1,15 @@
+export interface titleInterfaceProps {
+    isLoading?: boolean
+    itemName: string
+    panelTitle: string
+}
+
+export interface editorPanelTitleInterfaceProps {
+    proposalCode: number
+    panelTitle: string
+}
+
+export interface managerPanelTitleInterfaceProps {
+    proposalCycleCode: number
+    panelTitle: string
+}

--- a/src/main/webui/src/commonPanelFeatures/title.tsx
+++ b/src/main/webui/src/commonPanelFeatures/title.tsx
@@ -1,0 +1,74 @@
+import {Badge, Title} from "@mantine/core";
+import {ReactElement} from "react";
+import {
+    useProposalCyclesResourceGetProposalCycleTitle,
+    useProposalResourceGetObservingProposalTitle
+} from "../generated/proposalToolComponents.ts";
+
+interface titleInterfaceProps {
+    isLoading?: boolean
+    itemName: string
+    panelTitle: string
+}
+
+interface editorPanelTitleInterfaceProps {
+    proposalCode: number
+    panelTitle: string
+}
+
+interface managerPanelTitleInterfaceProps {
+    proposalCycleCode: number
+    panelTitle: string
+}
+
+export function PanelTitle(props: titleInterfaceProps): ReactElement {
+    return (
+        <Title order={3}>
+            { props.isLoading ?
+                <Badge size={"xl"} radius={0}>...</Badge> :
+                <Badge size={"xl"} radius={0}>{props.itemName}</Badge>
+            } : {props.panelTitle}
+        </Title>);
+}
+
+export function EditorPanelTitle(props: editorPanelTitleInterfaceProps) {
+    const {data, error, isLoading} =
+        useProposalResourceGetObservingProposalTitle(
+            {pathParams: {proposalCode: props.proposalCode}});
+
+    if(error) {
+        return (
+            <Title order={3}>
+                <Badge size={"xl"} radius={0}>UNKNOWN</Badge>
+                : {props.panelTitle}
+            </Title>
+        );
+    }
+
+    return (<PanelTitle
+        isLoading={isLoading}
+        itemName={data as unknown as string}
+        panelTitle={props.panelTitle} />);
+
+}
+
+export function ManagerPanelTitle(props: managerPanelTitleInterfaceProps) {
+    const {data, error, isLoading} =
+        useProposalCyclesResourceGetProposalCycleTitle(
+            {pathParams: {cycleCode: props.proposalCycleCode}});
+
+    if(error) {
+        return (
+            <Title order={3}>
+                <Badge size={"xl"} radius={0}>UNKNOWN</Badge>
+                : {props.panelTitle}
+            </Title>
+        );
+    }
+
+    return (<PanelTitle
+        isLoading={isLoading}
+        itemName={data as unknown as string}
+        panelTitle={props.panelTitle} />);
+
+}

--- a/src/main/webui/src/commonPanelFeatures/title.tsx
+++ b/src/main/webui/src/commonPanelFeatures/title.tsx
@@ -5,22 +5,12 @@ import {
     useProposalResourceGetObservingProposalTitle
 } from "../generated/proposalToolComponents.ts";
 
-interface titleInterfaceProps {
-    isLoading?: boolean
-    itemName: string
-    panelTitle: string
-}
+import {titleInterfaceProps, editorPanelTitleInterfaceProps, managerPanelTitleInterfaceProps} from "./panelFeatureInterfaceProps.tsx";
 
-interface editorPanelTitleInterfaceProps {
-    proposalCode: number
-    panelTitle: string
-}
-
-interface managerPanelTitleInterfaceProps {
-    proposalCycleCode: number
-    panelTitle: string
-}
-
+/**
+ * Render a panel title or ellipsis if still loading.
+ * @param {titleInterfaceProps} props
+ */
 export function PanelTitle(props: titleInterfaceProps): ReactElement {
     return (
         <Title order={3}>
@@ -31,6 +21,10 @@ export function PanelTitle(props: titleInterfaceProps): ReactElement {
         </Title>);
 }
 
+/**
+ * Lookup a proposal title then call PanelTitle() to render
+ * @param {editorPanelTitleInterfaceProps} props
+ */
 export function EditorPanelTitle(props: editorPanelTitleInterfaceProps) {
     const {data, error, isLoading} =
         useProposalResourceGetObservingProposalTitle(
@@ -52,6 +46,10 @@ export function EditorPanelTitle(props: editorPanelTitleInterfaceProps) {
 
 }
 
+/**
+ * Lookup an observing cycle title then call PanelTitle() to render
+ * @param {managerPanelTitleInterfaceProps} props
+ */
 export function ManagerPanelTitle(props: managerPanelTitleInterfaceProps) {
     const {data, error, isLoading} =
         useProposalCyclesResourceGetProposalCycleTitle(


### PR DESCRIPTION
All panel titles are now run through a common render function.  This can be called directly or via a wrapper function that will get the proposal or cycle title from the API first.

This has made some code redundant where we queried for titles in panels, so I've cleaned this up where appropriate.