### PR TITLE
126 manager view display possible allocationgrades

### DIFF
--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -64,7 +64,6 @@ import CycleOverviewPanel from "./ProposalManagerView/proposalCycle/overview.tsx
 import CycleDatesPanel from "./ProposalManagerView/proposalCycle/dates.tsx";
 import CycleObservingModesPanel from "./ProposalManagerView/observingModes/observingModesPanel.tsx";
 import CycleAvailableResourcesPanel from "./ProposalManagerView/availableResources/availableResourcesPanel.tsx";
-import CyclePossibleGradesPanel from "./ProposalManagerView/proposalCycle/possibleGrades.tsx";
 import CycleReviewsPanel from "./ProposalManagerView/reviews/reviewsPanel.tsx";
 import CycleAllocationsPanel from "./ProposalManagerView/allocations/allocationsPanel.tsx";
 import CycleObservatoryPanel from "./ProposalManagerView/proposalCycle/observatory.tsx";
@@ -163,10 +162,6 @@ function App2(): ReactElement {
                     {
                         path: "cycle/:selectedCycleCode/availableResources",
                         element: <CycleAvailableResourcesPanel />
-                    },
-                    {
-                        path: "cycle/:selectedCycleCode/possibleGrades",
-                        element: <CyclePossibleGradesPanel />
                     },
                     {
                         path: "cycle/:selectedCycleCode/reviews",

--- a/src/main/webui/src/ProposalManagerView/cycleList.tsx
+++ b/src/main/webui/src/ProposalManagerView/cycleList.tsx
@@ -3,7 +3,7 @@ import {Accordion, Group, NavLink} from "@mantine/core";
 import {
     IconBike,
     IconCalendar, IconEgg, IconLetterA,
-    IconLetterG, IconLetterO, IconLetterR,
+    IconLetterO, IconLetterR,
     IconLetterT,
     IconTeapot,
     IconUfo,
@@ -67,14 +67,6 @@ function CycleItem(props:{cycle: ObjectIdentifier}): ReactElement {
                          leftSection={<IconLetterT/>}
                          active={"Title" + cycle.code === active}
                          onClick={()=>setActive("Title" + cycle.code)}
-                />
-                <NavLink to={"cycle/" + cycle.dbid + "/possibleGrades"}
-                         component={Link}
-                         key={"Grades"}
-                         label={"Grades"}
-                         leftSection={<IconLetterG/>}
-                         active={"Grades" + cycle.code === active}
-                         onClick={()=>setActive("Grades" + cycle.code)}
                 />
                 <NavLink to={"cycle/" + cycle.dbid + "/dates"}
                          component={Link}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle.new.form.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle.new.form.tsx
@@ -10,8 +10,8 @@ import {
     fetchProposalCyclesResourceCreateProposalCycle
 } from "../generated/proposalToolComponents.ts";
 import getErrorMessage from "../errorHandling/getErrorMessage.tsx";
-import {useNavigate} from "react-router-dom";
-import {notifyError} from "../commonPanelFeatures/notifications.tsx";
+import {notifyError, notifySuccess} from "../commonPanelFeatures/notifications.tsx";
+import {useQueryClient} from "@tanstack/react-query";
 
 interface NewCycleFormProps {
     closeModal?: () => void
@@ -26,7 +26,7 @@ export default function NewCycleForm({closeModal}: NewCycleFormProps): ReactElem
         sessionEnd: Date | null,
         observatoryId: number | undefined
     }
-    const navigate = useNavigate();
+    const queryClient = useQueryClient();
 
     const [observatories, setObservatories]
         = useState<{ value: string, label: string }[]>([]);
@@ -98,12 +98,9 @@ export default function NewCycleForm({closeModal}: NewCycleFormProps): ReactElem
         }
 
         fetchProposalCyclesResourceCreateProposalCycle({body: newCycle})
-            .then(()=> {
-                window.location.reload();
-                navigate("/manager");
-            })
+            .then(()=> queryClient.invalidateQueries())
+            .then(() => notifySuccess("Success", "Proposal Cycle " + newCycle.title + " created"))
             .catch(console.error);
-
 
         closeModal && closeModal();
     }

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/TACMembersTable.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/TACMembersTable.tsx
@@ -1,0 +1,69 @@
+import {ReactElement} from "react";
+import {Table} from "@mantine/core";
+import {
+    useTACResourceGetCommitteeMember,
+    useTACResourceGetCommitteeMembers
+} from "../../generated/proposalToolComponents.ts";
+import {notifyError} from "../../commonPanelFeatures/notifications.tsx";
+import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
+
+export default function TACMembersTable(selectedCycleCode: number) : ReactElement {
+
+    const tacMembers = useTACResourceGetCommitteeMembers(
+        {pathParams:{cycleCode: selectedCycleCode}}
+    )
+
+    if (tacMembers.error) {
+        notifyError("Failed to load tac members list",
+            "cause: " + getErrorMessage(tacMembers.error))
+    }
+
+    const TACMembersTableHeader = () : ReactElement => {
+        return(
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th>Name</Table.Th>
+                    <Table.Th>Role</Table.Th>
+                    <Table.Th>Organisation</Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+        )
+    }
+
+    const TACMembersTableBody = () : ReactElement => {
+        return(
+            <Table.Tbody>
+                {tacMembers.data?.map((member) => {
+                    return TacMembersTableRow(member.dbid!)
+                })}
+            </Table.Tbody>
+        )
+    }
+
+    const TacMembersTableRow = (id: number) : ReactElement => {
+
+        const tacMember = useTACResourceGetCommitteeMember(
+            {pathParams:{cycleCode: selectedCycleCode, memberId: id}}
+        )
+
+        if (tacMember.error) {
+            notifyError("Failed to load TAC member id " + id,
+                "cause: " + getErrorMessage(tacMember.error))
+        }
+
+        return (
+            <Table.Tr key={String(id)}>
+                <Table.Td>{tacMember.data?.member?.person?.fullName}</Table.Td>
+                <Table.Td>{tacMember.data?.role}</Table.Td>
+                <Table.Td>{tacMember.data?.member?.person?.homeInstitute?.name}</Table.Td>
+            </Table.Tr>
+        )
+    }
+
+    return (
+        <Table>
+            <TACMembersTableHeader />
+            <TACMembersTableBody />
+        </Table>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/allocationGradesTable.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/allocationGradesTable.tsx
@@ -1,20 +1,22 @@
 import {ReactElement} from "react";
 import {Table} from "@mantine/core";
-import {useParams} from "react-router-dom";
 import {
     useProposalCyclesResourceGetCycleAllocatedGrade,
     useProposalCyclesResourceGetCycleAllocationGrades
 } from "../../generated/proposalToolComponents.ts";
-import {notifications} from "@mantine/notifications";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
+import {notifyError} from "../../commonPanelFeatures/notifications.tsx";
 
-export default function AllocationGradesTable() : ReactElement {
-
-    const {selectedCycleCode} = useParams();
+export default function AllocationGradesTable(selectedCycleCode: number) : ReactElement {
 
     const allocationGrades = useProposalCyclesResourceGetCycleAllocationGrades(
-        {pathParams: {cycleCode: Number(selectedCycleCode)}}
+        {pathParams: {cycleCode: selectedCycleCode}}
     )
+
+    if (allocationGrades.error) {
+        notifyError("Failed to load allocation grades list",
+            "cause: " + getErrorMessage(allocationGrades.error))
+    }
 
     const AllocationGradesTableHeader = () : ReactElement => {
         return (
@@ -30,16 +32,12 @@ export default function AllocationGradesTable() : ReactElement {
     const AllocationGradeTableRow = (id: number) : ReactElement  => {
 
         const allocationGrade = useProposalCyclesResourceGetCycleAllocatedGrade(
-            {pathParams:{cycleCode: Number(selectedCycleCode), gradeId: id}}
+            {pathParams:{cycleCode: selectedCycleCode, gradeId: id}}
         )
 
         if (allocationGrade.error) {
-            notifications.show({
-                message: "cause: " + getErrorMessage(allocationGrade.error),
-                title: "Failed to load allocation grade",
-                autoClose: 5000,
-                color: 'red'
-            })
+            notifyError("Failed to load allocation grade",
+                "cause: " + getErrorMessage(allocationGrade.error))
         }
 
         return (

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/availableResourcesTable.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/availableResourcesTable.tsx
@@ -1,0 +1,60 @@
+import {ReactElement} from "react";
+import {Table} from "@mantine/core";
+import {useAvailableResourcesResourceGetCycleResources} from "../../generated/proposalToolComponents.ts";
+import {notifyError} from "../../commonPanelFeatures/notifications.tsx";
+import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
+
+/*
+    We will likely want to show the total amount of "available resource" against how much has been allocated
+    to date
+ */
+
+export default function AvailableResourcesTable(selectedCycleCode: number) : ReactElement {
+
+   const availableResources = useAvailableResourcesResourceGetCycleResources(
+       {pathParams: {cycleCode: selectedCycleCode}}
+   )
+
+   if (availableResources.error) {
+       notifyError("Failed to load available resources list",
+           "cause: " + getErrorMessage(availableResources.error))
+   }
+
+   const AvailableResourcesTableHeader = () : ReactElement => {
+       return (
+           <Table.Thead>
+               <Table.Tr>
+                   <Table.Th>Name</Table.Th>
+                   <Table.Th>Unit</Table.Th>
+                   <Table.Th>Total</Table.Th>
+                   <Table.Th>Allocated</Table.Th>
+                   <Table.Th>Remaining</Table.Th>
+
+               </Table.Tr>
+           </Table.Thead>
+       )
+   }
+
+   const AvailableResourcesTableBody = () : ReactElement => {
+       return (
+           <Table.Tbody>
+               {availableResources.data?.map((ar) =>(
+                   <Table.Tr key={String(ar._id)}>
+                       <Table.Td>{ar.type?.name}</Table.Td>
+                       <Table.Td>{ar.type?.unit}</Table.Td>
+                       <Table.Td>{ar.amount}</Table.Td>
+                       <Table.Td c={"blue"}>{"not yet implemented"}</Table.Td>
+                       <Table.Td c={"blue"}>{"not yet implemented"}</Table.Td>
+                   </Table.Tr>
+               ))}
+           </Table.Tbody>
+       )
+   }
+
+    return (
+        <Table>
+            <AvailableResourcesTableHeader />
+            <AvailableResourcesTableBody />
+        </Table>
+    )
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/overview.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/overview.tsx
@@ -4,9 +4,12 @@ import {
     useProposalCyclesResourceGetProposalCycle
 } from "../../generated/proposalToolComponents.ts";
 import {useParams} from "react-router-dom";
-import AllocationGradesTable from "./possibleGrades.tsx";
-import {notifications} from "@mantine/notifications";
+import AllocationGradesTable from "./allocationGradesTable.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
+import {notifyError} from "../../commonPanelFeatures/notifications.tsx";
+import TACMembersTable from "./TACMembersTable.tsx";
+import SubmittedProposalsTable from "./submittedProposalsTable.tsx";
+import AvailableResourcesTable from "./availableResourcesTable.tsx";
 
 
 //ASSUMES input string is ISO date-time at GMT+0
@@ -20,7 +23,6 @@ function prettyDateTime(input : string ) : string {
     return date + " " + time + " GMT";
 }
 
-
 export default function CycleOverviewPanel() : ReactElement {
 
     const {selectedCycleCode} = useParams();
@@ -30,12 +32,8 @@ export default function CycleOverviewPanel() : ReactElement {
     )
 
     if (cycleSynopsis.error) {
-        notifications.show({
-            message: "cause " + getErrorMessage(cycleSynopsis.error),
-            title: "Failed to load proposal cycle synopsis",
-            autoClose: 5000,
-            color: 'red'
-        })
+        notifyError("Failed to load proposal cycle synopsis",
+            "cause " + getErrorMessage(cycleSynopsis.error))
     }
 
 
@@ -81,7 +79,7 @@ export default function CycleOverviewPanel() : ReactElement {
     const DisplayAllocationGrades = () : ReactElement => {
         return (
             <Fieldset legend={"Allocation Grades"}>
-                <AllocationGradesTable />
+                {AllocationGradesTable(Number(selectedCycleCode))}
             </Fieldset>
         )
     }
@@ -89,6 +87,7 @@ export default function CycleOverviewPanel() : ReactElement {
     const DisplayTACMembers = () : ReactElement => {
         return (
             <Fieldset legend={"TAC Members"}>
+                {TACMembersTable(Number(selectedCycleCode))}
             </Fieldset>
         )
     }
@@ -96,6 +95,7 @@ export default function CycleOverviewPanel() : ReactElement {
     const DisplaySubmittedProposals = () : ReactElement => {
         return (
             <Fieldset legend={"Submitted Proposals"}>
+                {SubmittedProposalsTable(Number(selectedCycleCode))}
             </Fieldset>
         )
     }
@@ -103,6 +103,7 @@ export default function CycleOverviewPanel() : ReactElement {
     const DisplayAvailableResources = () : ReactElement => {
         return (
             <Fieldset legend={"Available Resources"}>
+                {AvailableResourcesTable(Number(selectedCycleCode))}
             </Fieldset>
         )
     }

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/overview.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/overview.tsx
@@ -1,10 +1,12 @@
 import {ReactElement} from "react";
-import {Box, Container, Divider, Group, Stack, Text} from "@mantine/core";
+import { Container, Divider, Fieldset, Group, Space, Stack, Text} from "@mantine/core";
 import {
     useProposalCyclesResourceGetProposalCycle
 } from "../../generated/proposalToolComponents.ts";
 import {useParams} from "react-router-dom";
-import {JSON_SPACES} from "../../constants.tsx";
+import AllocationGradesTable from "./possibleGrades.tsx";
+import {notifications} from "@mantine/notifications";
+import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
 
 
 //ASSUMES input string is ISO date-time at GMT+0
@@ -23,64 +25,101 @@ export default function CycleOverviewPanel() : ReactElement {
 
     const {selectedCycleCode} = useParams();
 
-    const cycle = useProposalCyclesResourceGetProposalCycle(
+    const cycleSynopsis = useProposalCyclesResourceGetProposalCycle(
         {pathParams: {cycleCode: Number(selectedCycleCode)}}
     )
 
-    if (cycle.error) {
-        return (
-            <Box>
-                <pre>{JSON.stringify(cycle.error, null, JSON_SPACES)}</pre>
-            </Box>
-        );
+    if (cycleSynopsis.error) {
+        notifications.show({
+            message: "cause " + getErrorMessage(cycleSynopsis.error),
+            title: "Failed to load proposal cycle synopsis",
+            autoClose: 5000,
+            color: 'red'
+        })
     }
+
 
     const DisplayTitle = () : ReactElement => {
         return(
-            <h1>{cycle.data?.title}</h1>
+            <h1>{cycleSynopsis.data?.title}</h1>
         )
     }
 
     const DisplayDates = () : ReactElement => {
         return (
-            <Stack>
-                <h3>Important Dates</h3>
-                <Group grow>
-                <Text>Submission deadline:</Text>
-                    {
-                        cycle.data?.submissionDeadline &&
-                        <Text c={"orange"}> {prettyDateTime(cycle.data.submissionDeadline)}</Text>
-                    }
-                </Group>
-                <Divider />
-                <Group grow>
-                    <Text>Observation session start:</Text>
-                    {
-                        cycle.data?.observationSessionStart &&
-                        <Text c={"orange"}>{prettyDateTime(cycle.data.observationSessionStart)}</Text>
-                    }
-                </Group>
-                <Divider />
-                <Group grow>
-                    <Text>Observation session end:</Text>
-                    {
-                        cycle.data?.observationSessionEnd &&
-                        <Text c={"orange"}>{prettyDateTime(cycle.data.observationSessionEnd)}</Text>
-                    }
-                </Group>
-            </Stack>
+            <Fieldset legend={"Important Dates"}>
+                <Stack>
+                    <Group grow>
+                        <Text>Submission deadline:</Text>
+                        {
+                            cycleSynopsis.data?.submissionDeadline &&
+                            <Text c={"orange"}> {prettyDateTime(cycleSynopsis.data.submissionDeadline)}</Text>
+                        }
+                    </Group>
+                    <Divider />
+                    <Group grow>
+                        <Text>Observation session start:</Text>
+                        {
+                            cycleSynopsis.data?.observationSessionStart &&
+                            <Text c={"orange"}>{prettyDateTime(cycleSynopsis.data.observationSessionStart)}</Text>
+                        }
+                    </Group>
+                    <Divider />
+                    <Group grow>
+                        <Text>Observation session end:</Text>
+                        {
+                            cycleSynopsis.data?.observationSessionEnd &&
+                            <Text c={"orange"}>{prettyDateTime(cycleSynopsis.data.observationSessionEnd)}</Text>
+                        }
+                    </Group>
+                </Stack>
+            </Fieldset>
 
+        )
+    }
+
+    const DisplayAllocationGrades = () : ReactElement => {
+        return (
+            <Fieldset legend={"Allocation Grades"}>
+                <AllocationGradesTable />
+            </Fieldset>
+        )
+    }
+
+    const DisplayTACMembers = () : ReactElement => {
+        return (
+            <Fieldset legend={"TAC Members"}>
+            </Fieldset>
+        )
+    }
+
+    const DisplaySubmittedProposals = () : ReactElement => {
+        return (
+            <Fieldset legend={"Submitted Proposals"}>
+            </Fieldset>
+        )
+    }
+
+    const DisplayAvailableResources = () : ReactElement => {
+        return (
+            <Fieldset legend={"Available Resources"}>
+            </Fieldset>
         )
     }
 
 
     return (
-        <Container fluid>
+        <Container>
             <DisplayTitle />
             <DisplayDates />
-            {
-                //ToDo: display functions for other fields of a proposal cycle e.g., tac members, resources,...
-            }
+            <Space h={"xl"}/>
+            <DisplayAllocationGrades />
+            <Space h={"xl"}/>
+            <DisplayTACMembers />
+            <Space h={"xl"}/>
+            <DisplaySubmittedProposals />
+            <Space h={"xl"}/>
+            <DisplayAvailableResources />
         </Container>
     )
 }

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/possibleGrades.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/possibleGrades.tsx
@@ -1,15 +1,73 @@
 import {ReactElement} from "react";
-import {Container, Text} from "@mantine/core";
+import {Table} from "@mantine/core";
 import {useParams} from "react-router-dom";
-import {ManagerPanelTitle} from "../../commonPanelFeatures/title.tsx";
+import {
+    useProposalCyclesResourceGetCycleAllocatedGrade,
+    useProposalCyclesResourceGetCycleAllocationGrades
+} from "../../generated/proposalToolComponents.ts";
+import {notifications} from "@mantine/notifications";
+import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
 
-export default function CyclePossibleGradesPanel() : ReactElement {
+export default function AllocationGradesTable() : ReactElement {
+
     const {selectedCycleCode} = useParams();
 
-    return (
-        <Container fluid>
-            <ManagerPanelTitle proposalCycleCode={Number(selectedCycleCode)} panelTitle={"Grades"} />
-            <Text>WIP: this is where you view/edit the possible grades of a proposal cycle</Text>
-        </Container>
+    const allocationGrades = useProposalCyclesResourceGetCycleAllocationGrades(
+        {pathParams: {cycleCode: Number(selectedCycleCode)}}
+    )
+
+    const AllocationGradesTableHeader = () : ReactElement => {
+        return (
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th>Grade</Table.Th>
+                    <Table.Th>Description</Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+        )
+    }
+
+    const AllocationGradeTableRow = (id: number) : ReactElement  => {
+
+        const allocationGrade = useProposalCyclesResourceGetCycleAllocatedGrade(
+            {pathParams:{cycleCode: Number(selectedCycleCode), gradeId: id}}
+        )
+
+        if (allocationGrade.error) {
+            notifications.show({
+                message: "cause: " + getErrorMessage(allocationGrade.error),
+                title: "Failed to load allocation grade",
+                autoClose: 5000,
+                color: 'red'
+            })
+        }
+
+        return (
+            <Table.Tr key={String(id)}>
+                <Table.Td>{allocationGrade.data?.name}</Table.Td>
+                <Table.Td>{allocationGrade.data?.description}</Table.Td>
+            </Table.Tr>
+        )
+    }
+
+
+    const AllocationGradesTableBody= () : ReactElement => {
+        return (
+            <Table.Tbody>
+                {allocationGrades.data?.map((grade) => {
+                    return AllocationGradeTableRow(grade.dbid!)
+                })}
+            </Table.Tbody>
+        )
+    }
+
+    return(
+        <Table>
+            <AllocationGradesTableHeader />
+            <AllocationGradesTableBody />
+        </Table>
     )
 }
+
+
+

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/submittedProposalsTable.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/submittedProposalsTable.tsx
@@ -1,0 +1,53 @@
+import {ReactElement} from "react";
+import {Table} from "@mantine/core";
+import {useSubmittedProposalResourceGetSubmittedProposals} from "../../generated/proposalToolComponents.ts";
+import {notifyError} from "../../commonPanelFeatures/notifications.tsx";
+import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
+
+/*
+    We will likely want to add metadata about submitted proposals, the most useful of this being the
+    submitted proposals current "status" e.g., under-review, reviewed - success/fail, allocated
+ */
+
+export default function SubmittedProposalsTable(selectedCycleCode: number) : ReactElement {
+
+    const submittedProposals = useSubmittedProposalResourceGetSubmittedProposals(
+        {pathParams:{cycleCode: selectedCycleCode}}
+    )
+
+    if (submittedProposals.error) {
+        notifyError("Failed to load submitted proposals list",
+            "cause: " + getErrorMessage(submittedProposals.error))
+    }
+
+    const SubmittedProposalsTableHeader = () : ReactElement => {
+        return (
+            <Table.Thead>
+                <Table.Tr>
+                    <Table.Th>Proposal Title</Table.Th>
+                    <Table.Th>Current Status</Table.Th>
+                </Table.Tr>
+            </Table.Thead>
+        )
+    }
+
+    const SubmittedProposalsTableBody = () : ReactElement => {
+        return (
+            <Table.Tbody>
+                {submittedProposals.data?.map((sp) => (
+                    <Table.Tr key={String(sp.dbid)}>
+                        <Table.Td>{sp.name}</Table.Td>
+                        <Table.Td c={"blue"}>{"not yet implemented"}</Table.Td>
+                    </Table.Tr>
+                ))}
+            </Table.Tbody>
+        )
+    }
+
+    return (
+        <Table>
+            <SubmittedProposalsTableHeader />
+            <SubmittedProposalsTableBody />
+        </Table>
+    )
+}


### PR DESCRIPTION
Added possible allocation grades, tac members, submitted proposals and available resources tables to the overview panel of a proposal cycle. This also removes possible allocation grades has an editable entity. 