### PR TITLE
221 submit proposal after deadline

### DIFF
--- a/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
@@ -24,7 +24,7 @@ function SubmitPanel(): ReactElement {
     const [searchData, setSearchData] = useState([]);
     const [selectedCycle , setSelectedCycle] = useState(0);
     const [submissionDeadline, setSubmissionDeadline] = useState("undefined");
-    const [isValid, setIsValid] = useState(true);
+    const [isValid, setIsValid] = useState(false);
     const {data, error,  status} =
         useProposalCyclesResourceGetProposalCycles({queryParams: {includeClosed: false}});
     const queryClient = useQueryClient();
@@ -110,7 +110,7 @@ function SubmitPanel(): ReactElement {
                 <Grid>
                     <Grid.Col span={7}></Grid.Col>
                     <SubmitButton
-                        disabled={form.values.selectedCycle===0 && isValid}
+                        disabled={form.values.selectedCycle===0 || isValid == false}
                         label={"Submit proposal"}
                         toolTipLabel={"Submit your proposal to the selected cycle"}
                     />

--- a/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
@@ -24,6 +24,7 @@ function SubmitPanel(): ReactElement {
     const [searchData, setSearchData] = useState([]);
     const [selectedCycle , setSelectedCycle] = useState(0);
     const [submissionDeadline, setSubmissionDeadline] = useState("undefined");
+    const [isValid, setIsValid] = useState(true);
     const {data, error,  status} =
         useProposalCyclesResourceGetProposalCycles({queryParams: {includeClosed: false}});
     const queryClient = useQueryClient();
@@ -91,7 +92,7 @@ function SubmitPanel(): ReactElement {
         <PanelFrame>
             <EditorPanelHeader proposalCode={Number(selectedProposalCode)} panelHeading={"Submit"} />
 
-            <ValidationOverview cycle={selectedCycle}/>
+            <ValidationOverview cycle={selectedCycle} setValid={setIsValid}/>
 
             <form onSubmit={trySubmitProposal}>
                 <ContextualHelpButton messageId="ManageSubmit" />
@@ -109,7 +110,7 @@ function SubmitPanel(): ReactElement {
                 <Grid>
                     <Grid.Col span={7}></Grid.Col>
                     <SubmitButton
-                        disabled={form.values.selectedCycle===0}
+                        disabled={form.values.selectedCycle===0 && isValid}
                         label={"Submit proposal"}
                         toolTipLabel={"Submit your proposal to the selected cycle"}
                     />

--- a/src/main/webui/src/ProposalEditorView/proposal/ValidationOverview.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/ValidationOverview.tsx
@@ -43,7 +43,7 @@ export default function ValidationOverview(props: {cycle: number, setValid: any}
                                 {data?.info}
                             </Table.Td>
                         </Table.Tr>
-                        {data?.warnings !== "" &&
+                        {data?.warnings !== undefined &&
                             (<Table.Tr>
                                 <Table.Td>
                                     <IconAlertCircle size={ICON_SIZE} />
@@ -52,7 +52,7 @@ export default function ValidationOverview(props: {cycle: number, setValid: any}
                                     {data?.warnings}
                                 </Table.Td>
                             </Table.Tr>)}
-                        {data?.errors !== "" &&
+                        {data?.errors !== undefined &&
                             (<Table.Tr>
                                 <Table.Td>
                                     <IconCircleX size={ICON_SIZE} />

--- a/src/main/webui/src/ProposalEditorView/proposal/ValidationOverview.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/ValidationOverview.tsx
@@ -4,8 +4,9 @@ import {ICON_SIZE, JSON_SPACES} from "src/constants.tsx";
 import {useProposalResourceValidateObservingProposal} from "src/generated/proposalToolComponents.ts";
 import {useParams} from "react-router-dom";
 import {PanelFrame} from "../../commonPanel/appearance.tsx";
+import {useEffect} from "react";
 
-export default function ValidationOverview(props: {cycle: number}) {
+export default function ValidationOverview(props: {cycle: number, setValid: any}) {
     const { selectedProposalCode } = useParams();
     const {data, error, isLoading}
         = useProposalResourceValidateObservingProposal(
@@ -20,6 +21,11 @@ export default function ValidationOverview(props: {cycle: number}) {
             </Box>
         );
     }
+
+    useEffect(() => {
+        if(data?.isValid) { props.setValid(true); }
+        else {props.setValid(false)}
+    }, [data]);
 
     return (
         <PanelFrame m={20}>Validation overview


### PR DESCRIPTION
Changes to the submit proposal panel

* Validation status is now updated by the validation element
* Invalid proposal/cycle combinations cannot be submitted

This means proposals cannot be submitted to a cycle where the deadline has already passed as this is no longer a valid combination.
Please note this PR is dependant on an API change in [this PR](https://github.com/orppst/pst-api-service/pull/44).