### PR TITLE
Empty string showing as null or undefined

### DIFF
--- a/src/main/webui/src/ProposalEditorView/justifications/edit.modal.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/edit.modal.tsx
@@ -29,11 +29,7 @@ export default function JustificationsEditModal(justificationProps : Justificati
                 opened={opened}
                 onClose={props.closeModal}
                 title={"View/Edit " + capitalizeFirstChar(props.which) + " Justification"}
-                //fullScreen
-                size="auto"
-                height={75}
-                centered
-
+                size="60%"
             >
                 <JustificationForm {...props} />
             </Modal>

--- a/src/main/webui/src/ProposalEditorView/justifications/justification.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/justification.form.tsx
@@ -28,9 +28,9 @@ const JustificationTextArea = (form : UseFormReturnType<Justification>) => {
             return (
                 <Paper withBorder={true} bg={"gray.1"} c={"black"} p={"xs"} m={"xs"}>
                     <Editor
-                        value={form.values.text!}
+                        value={form.values.text ?? ""}
                         onValueChange={newValue => form.setValues({text: newValue, format: form.values.format})}
-                        highlight={code => highlight(code, languages.asciidoc, 'asciidoc')}
+                        highlight={code => highlight(code ?? "", languages.asciidoc, 'asciidoc')}
                         maxLength={MAX_CHARS_FOR_JUSTIFICATION}
                         {...form.getInputProps('text')}
                     />
@@ -40,9 +40,9 @@ const JustificationTextArea = (form : UseFormReturnType<Justification>) => {
             return (
                 <Paper withBorder={true} bg={"gray.1"} c={"black"} p={"xs"} m={"xs"}>
                     <Editor
-                        value={form.values.text!}
+                        value={form.values.text ?? ""}
                         onValueChange={newValue => form.setValues({text: newValue, format: form.values.format})}
-                        highlight={code => highlight(code, languages.latex, 'latex')}
+                        highlight={code => highlight(code ?? "", languages.latex, 'latex')}
                         maxLength={MAX_CHARS_FOR_JUSTIFICATION}
                         {...form.getInputProps('text')}
                     />
@@ -52,9 +52,9 @@ const JustificationTextArea = (form : UseFormReturnType<Justification>) => {
             return (
                 <Paper withBorder={true} bg={"gray.1"} c={"black"} p={"xs"} m={"xs"}>
                     <Editor
-                        value={form.values.text!}
+                        value={form.values.text ?? ""}
                         onValueChange={newValue => form.setValues({text: newValue, format: form.values.format})}
-                        highlight={code => highlight(code, languages.rest, 'rest')}
+                        highlight={code => highlight(code ?? "", languages.rest, 'rest')}
                         maxLength={MAX_CHARS_FOR_JUSTIFICATION}
                         {...form.getInputProps('text')}
                     />
@@ -155,7 +155,7 @@ export default function JustificationForm(props: JustificationProps)
             </Grid>
 
             </form>
-            {form.values.format==='latex' && PreviewJustification(form.values.format!, form.values.text!)}
+            {form.values.format==='latex' && PreviewJustification(form.values.format!, form.values.text ?? "")}
         </>
     );
 }

--- a/src/main/webui/src/ProposalEditorView/justifications/justifications.table.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/justifications.table.tsx
@@ -39,7 +39,7 @@ export default function JustificationsTable(justifications: JustificationKinds)
             <Table.Tbody>
                 <Table.Tr>
                     <Table.Td>Scientific</Table.Td>
-                    <Table.Td>{WordCount(justifications.scientific.text!)}</Table.Td>
+                    <Table.Td>{WordCount(justifications.scientific.text ?? "")}</Table.Td>
                     <Table.Td>{justifications.scientific.format}</Table.Td>
                     <Table.Td>
                         <JustificationsEditModal
@@ -49,7 +49,7 @@ export default function JustificationsTable(justifications: JustificationKinds)
                 </Table.Tr>
                 <Table.Tr>
                     <Table.Td>Technical</Table.Td>
-                    <Table.Td>{WordCount(justifications.technical.text!)}</Table.Td>
+                    <Table.Td>{WordCount(justifications.technical.text ?? "")}</Table.Td>
                     <Table.Td>{justifications.technical.format}</Table.Td>
                     <Table.Td>
                         <JustificationsEditModal


### PR DESCRIPTION
Add defensive checks when trying to do stuff with a Justification text strings, that are supposed to be the empty string but seemingly identify as null/undefined after being fetched from the api.  