### PR TITLE
Refine Cancel button

### DIFF
--- a/src/main/webui/src/ProposalEditorView/investigators/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/investigators/New.tsx
@@ -10,7 +10,6 @@ import {InvestigatorKind} from "src/generated/proposalToolSchemas.ts";
 import {Checkbox, Grid, Select, Stack} from "@mantine/core";
 import {useForm} from "@mantine/form";
 import {FormSubmitButton} from "src/commonButtons/save";
-import DeleteButton from "src/commonButtons/delete";
 import CancelButton from "src/commonButtons/cancel.tsx";
 import { JSON_SPACES } from 'src/constants.tsx';
 import {EditorPanelHeader, PanelFrame} from "../../commonPanel/appearance.tsx";

--- a/src/main/webui/src/ProposalEditorView/investigators/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/investigators/New.tsx
@@ -11,11 +11,12 @@ import {Checkbox, Grid, Select, Stack} from "@mantine/core";
 import {useForm} from "@mantine/form";
 import {FormSubmitButton} from "src/commonButtons/save";
 import DeleteButton from "src/commonButtons/delete";
+import CancelButton from "src/commonButtons/cancel.tsx";
 import { JSON_SPACES } from 'src/constants.tsx';
 import {EditorPanelHeader, PanelFrame} from "../../commonPanel/appearance.tsx";
 import {notifyError} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx";
 
 /**
  * Render s form panel to add an investigator to the current proposal.
@@ -129,10 +130,9 @@ function AddInvestigatorPanel(): ReactElement {
                     </Stack>
                     <p> </p>
                     <Grid >
-                       <Grid.Col span={8}></Grid.Col>
+                       <Grid.Col span={9}></Grid.Col>
                           <FormSubmitButton form={form} />
-                          <DeleteButton
-                             label={"Cancel"}
+                          <CancelButton
                              onClickEvent={handleCancel}
                              toolTipLabel={"Go back without saving"}/>
                      </Grid>

--- a/src/main/webui/src/ProposalEditorView/justifications/justification.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/justification.form.tsx
@@ -8,7 +8,6 @@ import {fetchProposalResourceUpdateJustification} from "src/generated/proposalTo
 import {useNavigate,useParams } from "react-router-dom";
 import {useQueryClient} from "@tanstack/react-query";
 import {FormSubmitButton} from "src/commonButtons/save.tsx";
-import DeleteButton from "src/commonButtons/delete";
 import CancelButton from "src/commonButtons/cancel.tsx";
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import {PreviewJustification} from "./justification.preview.tsx";

--- a/src/main/webui/src/ProposalEditorView/justifications/justification.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/justification.form.tsx
@@ -9,9 +9,10 @@ import {useNavigate,useParams } from "react-router-dom";
 import {useQueryClient} from "@tanstack/react-query";
 import {FormSubmitButton} from "src/commonButtons/save.tsx";
 import DeleteButton from "src/commonButtons/delete";
+import CancelButton from "src/commonButtons/cancel.tsx";
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import {PreviewJustification} from "./justification.preview.tsx";
-import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx";
 
 import Editor from "react-simple-code-editor";
 import { languages, highlight } from "prismjs";
@@ -130,9 +131,6 @@ export default function JustificationForm(props: JustificationProps)
     return (
         <>
             <form onSubmit={handleSubmit}>
-            {/*}
-            {helpButtonCall}
-            */}
             <ContextualHelpButton messageId="MaintSciJust" />
             <Stack>
                <Grid span={10} grow>
@@ -148,8 +146,7 @@ export default function JustificationForm(props: JustificationProps)
             <Grid>
               <Grid.Col span={8}></Grid.Col>
                  <FormSubmitButton form={form} />
-                 <DeleteButton
-                    label={"Cancel"}
+                 <CancelButton
                     onClickEvent={handleCancel}
                     toolTipLabel={"Go back without saving"}/>
             </Grid>

--- a/src/main/webui/src/ProposalEditorView/observationFields/observationFields.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/observationFields.form.tsx
@@ -13,6 +13,7 @@ import {
 import {useForm} from "@mantine/form";
 import {SubmitButton} from "../../commonButtons/save.tsx";
 import DeleteButton from "src/commonButtons/delete.tsx";
+import CancelButton from "src/commonButtons/cancel.tsx";
 import {
     fetchProposalResourceAddNewField,
     fetchProposalResourceChangeFieldName
@@ -21,7 +22,7 @@ import {useParams, useNavigate} from "react-router-dom";
 import {useQueryClient} from "@tanstack/react-query";
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx";
 
 /**
  * Function to return the "Observation Fields" form to either create a new "Field" or edit an existing one.
@@ -214,10 +215,9 @@ export default function ObservationFieldsForm(props: ObservationFieldsProps) : R
                     </Stack>
                 }
             </Stack>
-                        <p> </p>
-                        <Grid>
-                          <Grid.Col span={7}></Grid.Col>
-
+            <p> </p>
+            <Grid>
+                <Grid.Col span={7}></Grid.Col>
                 <SubmitButton
                     toolTipLabel={props.observationField ? "Save Changes" : "Save new Field"}
                     label={"Save"}
@@ -225,12 +225,10 @@ export default function ObservationFieldsForm(props: ObservationFieldsProps) : R
                         form.values.fieldType === 'proposal:Ellipse' ||
                         form.values.fieldType === 'proposal:Polygon'}
                         />
-                 <DeleteButton
-                     label={"Cancel"}
+                 <CancelButton
                      onClickEvent={handleCancel}
                      toolTipLabel={"Go back without saving"}/>
-                 </Grid>
-
+            </Grid>
         </form>
     )
 }

--- a/src/main/webui/src/ProposalEditorView/observationFields/observationFields.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/observationFields.form.tsx
@@ -12,7 +12,6 @@ import {
 } from "../../generated/proposalToolSchemas.ts";
 import {useForm} from "@mantine/form";
 import {SubmitButton} from "../../commonButtons/save.tsx";
-import DeleteButton from "src/commonButtons/delete.tsx";
 import CancelButton from "src/commonButtons/cancel.tsx";
 import {
     fetchProposalResourceAddNewField,

--- a/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
@@ -15,7 +15,6 @@ import {
     fetchObservationResourceReplaceTimingWindow
 } from 'src/generated/proposalToolComponents.ts';
 import {FormSubmitButton} from 'src/commonButtons/save.tsx';
-import DeleteButton from 'src/commonButtons/delete.tsx';
 import CancelButton from "src/commonButtons/cancel.tsx";
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';

--- a/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
@@ -16,11 +16,12 @@ import {
 } from 'src/generated/proposalToolComponents.ts';
 import {FormSubmitButton} from 'src/commonButtons/save.tsx';
 import DeleteButton from 'src/commonButtons/delete.tsx';
+import CancelButton from "src/commonButtons/cancel.tsx";
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { FormEvent, ReactElement, SyntheticEvent } from 'react';
 import { TimingWindowGui } from './timingWindowGui.tsx';
-import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx";
 
 /**
  * the different types of observation.
@@ -307,8 +308,7 @@ export default function ObservationEditGroup(
                                     <Grid>
                                       <Grid.Col span={7}></Grid.Col>
                                          <FormSubmitButton form={form} />
-                                         <DeleteButton
-                                            label={"Cancel"}
+                                         <CancelButton
                                             onClickEvent={handleCancel}
                                             toolTipLabel={"Go back without saving"}/>
                                     </Grid>

--- a/src/main/webui/src/ProposalEditorView/proposal/Documents.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Documents.tsx
@@ -12,6 +12,7 @@ import {modals} from "@mantine/modals";
 import {randomId} from "@mantine/hooks";
 import UploadButton from 'src/commonButtons/upload.tsx';
 import DeleteButton from 'src/commonButtons/delete.tsx';
+import CancelButton from "src/commonButtons/cancel.tsx";
 import {
     DownloadButton,
     DownloadRequestButton
@@ -20,7 +21,7 @@ import {HEADER_FONT_WEIGHT, JSON_SPACES, MAX_SUPPORTING_DOCUMENT_SIZE} from 'src
 import {EditorPanelHeader, PanelFrame} from "../../commonPanel/appearance.tsx";
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx";
 
 type DocumentProps = {
     dbid: number,
@@ -124,11 +125,10 @@ const DocumentsPanel = () => {
                                 label={"Choose a file"}
                                 onClick={props.onClick}/>}
                 </FileButton>
-                                 <DeleteButton
-                                    label={"Cancel"}
-                                    onClickEvent={handleCancel}
-                                    toolTipLabel={"Go back without saving"}/>
-                                    </Grid>
+                <CancelButton
+                    onClickEvent={handleCancel}
+                    toolTipLabel={"Go back without saving"}/>
+                </Grid>
                 <Result status={status} />
             </Stack>
         </PanelFrame>

--- a/src/main/webui/src/ProposalEditorView/proposal/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/New.tsx
@@ -17,12 +17,13 @@ import {useForm} from "@mantine/form";
 import {useQueryClient} from "@tanstack/react-query";
 import {FormSubmitButton} from 'src/commonButtons/save';
 import DeleteButton from 'src/commonButtons/delete';
+import CancelButton from "src/commonButtons/cancel.tsx";
 import { MAX_CHARS_FOR_INPUTS, TEXTAREA_MAX_ROWS } from "src/constants";
 import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.tsx";
 import {PanelFrame, PanelHeader} from "../../commonPanel/appearance.tsx";
 import {notifyError} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx";
 
 
 const kindData = [
@@ -103,11 +104,11 @@ const textFormatData = [
             });
     });
 
-
   function handleCancel(event: SyntheticEvent) {
       event.preventDefault();
       navigate("/",{relative:"path"})
       }
+
      return (
         <PanelFrame>
             <PanelHeader itemName={"NEW"} panelHeading={"Create Proposal"} />
@@ -141,10 +142,9 @@ const textFormatData = [
                     />
             <p> </p>
             <Grid>
-              <Grid.Col span={8}></Grid.Col>
+              <Grid.Col span={9}></Grid.Col>
                  <FormSubmitButton form={form} />
-                 <DeleteButton
-                    label={"Cancel"}
+                 <CancelButton
                     onClickEvent={handleCancel}
                     toolTipLabel={"Go back without saving"}/>
             </Grid>
@@ -193,10 +193,9 @@ const textFormatData = [
                     />
             <p> </p>
             <Grid>
-              <Grid.Col span={8}></Grid.Col>
+              <Grid.Col span={9}></Grid.Col>
                  <FormSubmitButton form={form} />
-                 <DeleteButton
-                    label={"Cancel"}
+                 <CancelButton
                     onClickEvent={handleCancel}
                     toolTipLabel={"Go back without saving"}/>
             </Grid>

--- a/src/main/webui/src/ProposalEditorView/proposal/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/New.tsx
@@ -16,7 +16,6 @@ import {Box, Container, Grid, Select, Text, Textarea, TextInput, Stack, Space} f
 import {useForm} from "@mantine/form";
 import {useQueryClient} from "@tanstack/react-query";
 import {FormSubmitButton} from 'src/commonButtons/save';
-import DeleteButton from 'src/commonButtons/delete';
 import CancelButton from "src/commonButtons/cancel.tsx";
 import { MAX_CHARS_FOR_INPUTS, TEXTAREA_MAX_ROWS } from "src/constants";
 import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.tsx";

--- a/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
@@ -11,12 +11,13 @@ import {useForm} from "@mantine/form";
 import {JSON_SPACES} from "src/constants.tsx";
 import {SubmitButton} from "src/commonButtons/save.tsx";
 import DeleteButton from "src/commonButtons/delete.tsx";
+import CancelButton from "src/commonButtons/cancel.tsx";
 import {useQueryClient} from "@tanstack/react-query";
 import ValidationOverview from "./ValidationOverview.tsx";
 import {EditorPanelHeader, PanelFrame} from "../../commonPanel/appearance.tsx";
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx";
 
 function SubmitPanel(): ReactElement {
     const {selectedProposalCode} = useParams();
@@ -108,14 +109,13 @@ function SubmitPanel(): ReactElement {
 
                 <p> </p>
                 <Grid>
-                    <Grid.Col span={7}></Grid.Col>
+                    <Grid.Col span={8}></Grid.Col>
                     <SubmitButton
                         disabled={form.values.selectedCycle===0 || isValid == false}
                         label={"Submit proposal"}
                         toolTipLabel={"Submit your proposal to the selected cycle"}
                     />
-                    <DeleteButton
-                        label={"Cancel"}
+                    <CancelButton
                         onClickEvent={handleCancel}
                         toolTipLabel={"Go back without submitting"}/>
                 </Grid>

--- a/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Submit.tsx
@@ -10,7 +10,6 @@ import {useNavigate, useParams} from "react-router-dom";
 import {useForm} from "@mantine/form";
 import {JSON_SPACES} from "src/constants.tsx";
 import {SubmitButton} from "src/commonButtons/save.tsx";
-import DeleteButton from "src/commonButtons/delete.tsx";
 import CancelButton from "src/commonButtons/cancel.tsx";
 import {useQueryClient} from "@tanstack/react-query";
 import ValidationOverview from "./ValidationOverview.tsx";

--- a/src/main/webui/src/ProposalEditorView/proposal/Summary.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Summary.tsx
@@ -10,6 +10,7 @@ import {Box, Grid, Stack, Textarea} from "@mantine/core";
 import {useForm} from "@mantine/form";
 import {FormSubmitButton} from 'src/commonButtons/save';
 import DeleteButton from "src/commonButtons/delete";
+import CancelButton from "src/commonButtons/cancel.tsx";
 import {
     JSON_SPACES,
     MAX_CHARS_FOR_INPUTS, TEXTAREA_MAX_ROWS
@@ -18,7 +19,7 @@ import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.
 import {PanelFrame, PanelHeader} from "../../commonPanel/appearance.tsx";
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx";
 
 function SummaryPanel() {
     const { selectedProposalCode } = useParams();
@@ -109,10 +110,9 @@ function SummaryPanel() {
                 </Stack>
                 <p> </p>
                 <Grid >
-                   <Grid.Col span={8}></Grid.Col>
+                   <Grid.Col span={9}></Grid.Col>
                        <FormSubmitButton form={form} />
-                       <DeleteButton
-                           label={"Cancel"}
+                       <CancelButton
                             onClickEvent={handleCancel}
                             toolTipLabel={"Go back without saving"}/>
                 </Grid>

--- a/src/main/webui/src/ProposalEditorView/proposal/Summary.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Summary.tsx
@@ -9,7 +9,6 @@ import {useNavigate, useParams} from "react-router-dom";
 import {Box, Grid, Stack, Textarea} from "@mantine/core";
 import {useForm} from "@mantine/form";
 import {FormSubmitButton} from 'src/commonButtons/save';
-import DeleteButton from "src/commonButtons/delete";
 import CancelButton from "src/commonButtons/cancel.tsx";
 import {
     JSON_SPACES,

--- a/src/main/webui/src/ProposalEditorView/proposal/Title.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Title.tsx
@@ -10,12 +10,13 @@ import {useNavigate, useParams} from "react-router-dom";
 import {useForm} from "@mantine/form";
 import {FormSubmitButton} from 'src/commonButtons/save';
 import DeleteButton from "src/commonButtons/delete";
+import CancelButton from "src/commonButtons/cancel.tsx";
 import { MAX_CHARS_FOR_INPUTS, JSON_SPACES } from 'src/constants';
 import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.tsx";
 import {PanelFrame, PanelHeader} from "../../commonPanel/appearance.tsx";
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx";
 
 const titleFormJSON =  {
     initialValues: {title: "Loading..."},
@@ -110,12 +111,12 @@ function TitlePanel() {
                 </Stack>
                 <p> </p>
                 <Grid >
-                   <Grid.Col span={8}></Grid.Col>
+                   <Grid.Col span={9}></Grid.Col>
                       <FormSubmitButton form={form} />
-                      <DeleteButton
-                          label={"Cancel"}
-                          onClickEvent={handleCancel}
-                          toolTipLabel={"Go back without saving"}/>
+                      <CancelButton
+                           onClickEvent={handleCancel}
+                           toolTipLabel={"Go back without saving"}
+                           />
                 </Grid>
                 <p> </p>
             </form>

--- a/src/main/webui/src/ProposalEditorView/proposal/Title.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Title.tsx
@@ -9,7 +9,6 @@ import {Grid, Stack, TextInput} from "@mantine/core";
 import {useNavigate, useParams} from "react-router-dom";
 import {useForm} from "@mantine/form";
 import {FormSubmitButton} from 'src/commonButtons/save';
-import DeleteButton from "src/commonButtons/delete";
 import CancelButton from "src/commonButtons/cancel.tsx";
 import { MAX_CHARS_FOR_INPUTS, JSON_SPACES } from 'src/constants';
 import MaxCharsForInputRemaining from "src/commonInputs/remainingCharacterCount.tsx";

--- a/src/main/webui/src/ProposalEditorView/targets/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/New.tsx
@@ -21,7 +21,6 @@ import {
 import {useQueryClient} from "@tanstack/react-query";
 import {useNavigate, useParams} from "react-router-dom";
 import AddButton from 'src/commonButtons/add';
-import DeleteButton from 'src/commonButtons/delete.tsx';
 import CancelButton from "src/commonButtons/cancel.tsx";
 import DatabaseSearchButton from 'src/commonButtons/databaseSearch';
 import { SubmitButton } from 'src/commonButtons/save';

--- a/src/main/webui/src/ProposalEditorView/targets/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/New.tsx
@@ -22,6 +22,7 @@ import {useQueryClient} from "@tanstack/react-query";
 import {useNavigate, useParams} from "react-router-dom";
 import AddButton from 'src/commonButtons/add';
 import DeleteButton from 'src/commonButtons/delete.tsx';
+import CancelButton from "src/commonButtons/cancel.tsx";
 import DatabaseSearchButton from 'src/commonButtons/databaseSearch';
 import { SubmitButton } from 'src/commonButtons/save';
 import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
@@ -381,8 +382,7 @@ const TargetForm = (props: FormPropsType<newTargetData>): ReactElement => {
                            toolTipLabel={"Save this target"}
                            disabled={!form.isValid() ||
                            form.values.searching? true : undefined}/>
-                       <DeleteButton
-                           label={"Cancel"}
+                       <CancelButton
                            onClickEvent={handleCancel}
                            toolTipLabel={"Go back without saving"}/>
                     </Grid>

--- a/src/main/webui/src/ProposalEditorView/targets/targetPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/targetPanel.tsx
@@ -10,7 +10,7 @@ import { ReactElement } from 'react';
 import { JSON_SPACES } from 'src/constants.tsx';
 import { TargetTable } from './TargetTable.tsx';
 import {EditorPanelHeader, PanelFrame} from "../../commonPanel/appearance.tsx";
-import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx";
 
 /**
  * Renders the target panel containing an add target button
@@ -65,12 +65,12 @@ export function TargetPanel(): ReactElement {
                 }
 
             </Stack>
-                        <p> </p>
-                        <Grid>
-                          <Grid.Col span={10}></Grid.Col>
-                                          <AddTargetModal/>
-                                          </Grid>
-                                          <p> </p>
+            <p> </p>
+             <Grid>
+                <Grid.Col span={10}></Grid.Col>
+                <AddTargetModal/>
+             </Grid>
+             <p> </p>
         </PanelFrame>
     );
 }

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/edit.group.tsx
@@ -18,7 +18,6 @@ import {
     fetchTechnicalGoalResourceReplacePerformanceParameters, fetchTechnicalGoalResourceReplaceSpectrum
 } from "src/generated/proposalToolComponents.ts";
 import {FormSubmitButton} from "src/commonButtons/save.tsx";
-import DeleteButton from "src/commonButtons/delete.tsx";
 import CancelButton from "src/commonButtons/cancel.tsx";
 import {
     convertToPerformanceParameters,

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/edit.group.tsx
@@ -19,13 +19,14 @@ import {
 } from "src/generated/proposalToolComponents.ts";
 import {FormSubmitButton} from "src/commonButtons/save.tsx";
 import DeleteButton from "src/commonButtons/delete.tsx";
+import CancelButton from "src/commonButtons/cancel.tsx";
 import {
     convertToPerformanceParameters,
     convertToPerformanceParametersGui,
     PerformanceParametersGui
 } from "./performanceParametersGui.tsx";
 import {notifySuccess} from "../../commonPanel/notifications.tsx";
-import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx"
+import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx";
 
 export const notSpecified = "not specified";
 export const notSet = "not set";
@@ -284,8 +285,7 @@ export default function TechnicalGoalEditGroup(
                     <Grid>
                     <Grid.Col span={8}></Grid.Col>
                        <FormSubmitButton form={form} />
-                       <DeleteButton
-                          label={"Cancel"}
+                       <CancelButton
                           onClickEvent={handleCancel}
                            toolTipLabel={"Go back without saving"}/>
                      </Grid>

--- a/src/main/webui/src/commonButtons/cancel.tsx
+++ b/src/main/webui/src/commonButtons/cancel.tsx
@@ -1,0 +1,37 @@
+import { Button, Tooltip } from '@mantine/core';
+import { IconPlayerSkipBack } from '@tabler/icons-react';
+import {
+    ClickButtonInterfaceProps
+} from './buttonInterfaceProps.tsx';
+import { ReactElement } from 'react';
+import { CLOSE_DELAY, ICON_SIZE, OPEN_DELAY } from '../constants.tsx';
+
+
+/**
+ * creates a Cancel button.
+ *
+ * @param {ClickButtonInterfaceProps} props the button inputs.
+ * @return {ReactElement} the dynamic html for the Cancel button
+ * @constructor
+ */
+export default
+function CancelButton(props: ClickButtonInterfaceProps): ReactElement {
+    return (
+        <Tooltip
+            position={props.toolTipLabelPosition}
+            openDelay={OPEN_DELAY}
+            closeDelay={CLOSE_DELAY}
+            label={props.toolTipLabel}
+        >
+            <Button
+                rightSection={<IconPlayerSkipBack size={ICON_SIZE}/>}
+                color={"red.5"}
+                variant={props.variant ?? "subtle"}
+                onClick={props.onClick ?? props.onClickEvent}
+                disabled={props.disabled}
+            >
+                {props.label ?? 'Cancel'}
+            </Button>
+        </Tooltip>
+    )
+}


### PR DESCRIPTION
Previously was implemented as repurposed DeleteButton. So, created new CancelButton following Polaris standard in commonButtons with a more appropriate icon and called that where required. Ideally, would make handleCancel a single callable feature too...