### PR TITLE
219 observation fields duplicates

### DIFF
--- a/src/main/webui/public/contextualHelpMessages.jsx
+++ b/src/main/webui/public/contextualHelpMessages.jsx
@@ -115,7 +115,7 @@ export const contextualHelpMessages = [
 }
 , {
   id: "MaintObsField-eng",
-  message: " Enter a field name and select its type."
+  message: " Enter a unique field name and select its type."
          + " Save your changes with the Save button at bottom right, or cancel and return without saving by clicking the Cancel button."
 }
 , {

--- a/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
@@ -10,6 +10,7 @@ import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
 
 export type ObservationFieldsProps = {
     observationField: Field | undefined
+    fieldCount: number | undefined
     closeModal?: () => void
 }
 
@@ -33,6 +34,9 @@ export default function ObservationFieldsPanel() : ReactElement {
     boundFields = proposal.data?.observations?.map(obs => (
         obs.field! as number)
     )
+
+
+    const fieldCount = proposal.data?.fields?.length ?? 0;
 
     //Remove the "Card" once we have this fully implemented
 
@@ -65,7 +69,7 @@ export default function ObservationFieldsPanel() : ReactElement {
             <Space h={"xl"}/>
             <Grid>
               <Grid.Col span={10}></Grid.Col>
-                              <ObservationFieldModal observationField={undefined} />
+                              <ObservationFieldModal observationField={undefined} fieldCount={fieldCount} />
                               </Grid>
               {/*}
            <Group justify={'center'}>

--- a/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
@@ -16,6 +16,7 @@ export type ObservationFieldsProps = {
 
 export type ObservationFieldsTableProps = {
     boundFields: number[] | undefined
+    fieldNames?: string[]
 }
 
 /**
@@ -64,12 +65,13 @@ export default function ObservationFieldsPanel() : ReactElement {
                 </Card>
             </Group>
 
-            <ObservationFieldsTable boundFields={boundFields} />
+            <ObservationFieldsTable boundFields={boundFields} fieldNames={fieldNames}/>
 
             <Space h={"xl"}/>
             <Grid>
               <Grid.Col span={10}></Grid.Col>
-                              <ObservationFieldModal observationField={undefined} fieldNames={fieldNames} />
+                              <ObservationFieldModal observationField={undefined}
+                                                     fieldNames={fieldNames} />
                               </Grid>
               {/*}
            <Group justify={'center'}>

--- a/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
@@ -10,7 +10,7 @@ import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
 
 export type ObservationFieldsProps = {
     observationField: Field | undefined
-    fieldCount: number | undefined
+    fieldCount?: number
     closeModal?: () => void
 }
 
@@ -34,7 +34,6 @@ export default function ObservationFieldsPanel() : ReactElement {
     boundFields = proposal.data?.observations?.map(obs => (
         obs.field! as number)
     )
-
 
     const fieldCount = proposal.data?.fields?.length ?? 0;
 

--- a/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
@@ -10,7 +10,7 @@ import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
 
 export type ObservationFieldsProps = {
     observationField: Field | undefined
-    fieldCount?: number
+    fieldNames?: string[]
     closeModal?: () => void
 }
 
@@ -35,7 +35,8 @@ export default function ObservationFieldsPanel() : ReactElement {
         obs.field! as number)
     )
 
-    const fieldCount = proposal.data?.fields?.length ?? 0;
+    let fieldNames : string[] = [];
+    proposal.data?.fields?.map(field => (fieldNames.push(field.name!)));
 
     //Remove the "Card" once we have this fully implemented
 
@@ -68,7 +69,7 @@ export default function ObservationFieldsPanel() : ReactElement {
             <Space h={"xl"}/>
             <Grid>
               <Grid.Col span={10}></Grid.Col>
-                              <ObservationFieldModal observationField={undefined} fieldCount={fieldCount} />
+                              <ObservationFieldModal observationField={undefined} fieldNames={fieldNames} />
                               </Grid>
               {/*}
            <Group justify={'center'}>

--- a/src/main/webui/src/ProposalEditorView/observationFields/observationFields.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/observationFields.form.tsx
@@ -60,7 +60,7 @@ export default function ObservationFieldsForm(props: ObservationFieldsProps) : R
         ellipsePAMajor?: RealQuantity
     }
 
-    let newFieldCount = props.fieldCount ?? 0;
+    let newFieldCount = props.fieldNames?.length ?? 0;
     newFieldCount += 1;
     const newFieldName = "Field " + newFieldCount;
 
@@ -81,7 +81,9 @@ export default function ObservationFieldsForm(props: ObservationFieldsProps) : R
                 (value === undefined ? 'Please select a Field Type' : null),
             fieldName: (value: string | undefined) =>
                 (value === undefined ? 'Please give the Field a name' :
-                    value.length < 2 ? 'Name must have at least 2 characters' : null),
+                    value.length < 2 ? 'Name must have at least 2 characters' :
+                        props.fieldNames?.includes(value) ? 'Name must be unique' :
+                        null),
         }
     });
 

--- a/src/main/webui/src/ProposalEditorView/observationFields/observationFields.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/observationFields.form.tsx
@@ -39,7 +39,7 @@ export default function ObservationFieldsForm(props: ObservationFieldsProps) : R
         Developer note: If more Field types are added to the underlying data model then this array
         must be edited to match. There is another Field type named "Point" not listed in this array
         that consist of a member called "centre" with a Java Type of "Coordinate", but I am unsure
-        how this differs from the "TargetField" type.
+        how this differs from the "TargetField" type.3
      */
     let fieldTypeData: {value: string, label: string, description?: string} [] = [
         {value: 'proposal:TargetField', label: "Target",
@@ -60,12 +60,15 @@ export default function ObservationFieldsForm(props: ObservationFieldsProps) : R
         ellipsePAMajor?: RealQuantity
     }
 
+    let newFieldCount = props.fieldCount ?? 0;
+    newFieldCount += 1;
+    const newFieldName = "Field " + newFieldCount;
 
     const form = useForm<ObservationFieldValues>({
         validateInputOnBlur: true,
         initialValues: {
             fieldType: props.observationField?.["@type"],
-            fieldName: props.observationField?.name,
+            fieldName: props.observationField?.name ?? newFieldName,
             centre: undefined,
             polygonPoints: undefined,
             ellipseSemiMajor: undefined,

--- a/src/main/webui/src/ProposalEditorView/observationFields/observationFieldsTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/observationFieldsTable.tsx
@@ -82,7 +82,7 @@ function ObservationFieldsRow(props: ObservationFieldRowProps): ReactElement {
             <Table.Td c={"blue"}>not yet implemented</Table.Td>
             <Table.Td c={"gray"}>
                 <Group justify={"flex-end"}>
-                    <ObservationFieldModal observationField={field.data} fieldCount={undefined}/>
+                    <ObservationFieldModal observationField={field.data}/>
                     <DeleteButton
                         disabled={props.disableDelete}
                         toolTipLabel={props.disableDelete ?

--- a/src/main/webui/src/ProposalEditorView/observationFields/observationFieldsTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/observationFieldsTable.tsx
@@ -18,7 +18,8 @@ import {ObservationFieldsTableProps} from "./ObservationFieldsPanel.tsx";
 type ObservationFieldRowProps = {
     proposalCode: number,
     fieldId: number,
-    disableDelete: boolean
+    disableDelete: boolean,
+    otherFieldNames?: string[]
 }
 
 function ObservationFieldsRow(props: ObservationFieldRowProps): ReactElement {
@@ -82,7 +83,8 @@ function ObservationFieldsRow(props: ObservationFieldRowProps): ReactElement {
             <Table.Td c={"blue"}>not yet implemented</Table.Td>
             <Table.Td c={"gray"}>
                 <Group justify={"flex-end"}>
-                    <ObservationFieldModal observationField={field.data}/>
+                    <ObservationFieldModal observationField={field.data}
+                                           fieldNames={props.otherFieldNames}/>
                     <DeleteButton
                         disabled={props.disableDelete}
                         toolTipLabel={props.disableDelete ?
@@ -133,6 +135,7 @@ export default function ObservationFieldsTable(props: ObservationFieldsTableProp
                         fieldId={fieldId.dbid!}
                         proposalCode={Number(selectedProposalCode)}
                         disableDelete={isFieldBound(fieldId.dbid!)}
+                        otherFieldNames={props.fieldNames}
                     />
                 ))
             }

--- a/src/main/webui/src/ProposalEditorView/observationFields/observationFieldsTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/observationFieldsTable.tsx
@@ -82,7 +82,7 @@ function ObservationFieldsRow(props: ObservationFieldRowProps): ReactElement {
             <Table.Td c={"blue"}>not yet implemented</Table.Td>
             <Table.Td c={"gray"}>
                 <Group justify={"flex-end"}>
-                    <ObservationFieldModal observationField={field.data} />
+                    <ObservationFieldModal observationField={field.data} fieldCount={undefined}/>
                     <DeleteButton
                         disabled={props.disableDelete}
                         toolTipLabel={props.disableDelete ?


### PR DESCRIPTION
This assigns a default / suggested name to new fields taking the form of "Field" plus an ordinal number given how many fields already exist.

It also blocks duplicate names, and the contextual help is updated to say field names are unique.