### PR TITLE
Delete proposal in Overview Panel

### DIFF
--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -3,7 +3,7 @@ import {
     useContext,
     ReactElement,
     SyntheticEvent,
-    Context, StrictMode
+    Context, StrictMode, useReducer
 } from 'react';
 import {
     QueryClient,
@@ -134,13 +134,17 @@ function App2(): ReactElement {
 
     const GRAY = theme.colors.gray[6];
 
+    // hack to force the left-hand navbar to update after proposal deletion in Overview panel
+    // more precisely, when called, "forceUpdate" will make the entire App rerender - use sparingly!!
+    const [,forceUpdate] = useReducer(x => x + 1, 0);
+
     // the paths to route to.
     const router = createBrowserRouter(
         [
             {
                 path: "/manager",
                 element: <PSTManager />,
-                    errorElement: <ErrorPage />,
+                errorElement: <ErrorPage />,
                 children: [
                     {index: true, element: <PSTManagerStart />},
                     {
@@ -203,7 +207,7 @@ function App2(): ReactElement {
             {
                 path: "/",
                 element: <PSTEditor/>,
-                                    errorElement: <ErrorPage />,
+                errorElement: <ErrorPage />,
                 children: [
                     {index: true, element: <PSTStart/>} ,
                     {
@@ -218,7 +222,8 @@ function App2(): ReactElement {
                     },
                     {
                         path: "proposal/:selectedProposalCode",
-                        element: <OverviewPanel />,
+                        //'forceUpdate' is called following a proposal deletion in Overview panel
+                        element: <OverviewPanel forceUpdate={forceUpdate}/>,
                         errorElement: <ErrorPage />,
                     },
                     {
@@ -429,15 +434,18 @@ function App2(): ReactElement {
                             </Container>
 
                         <AddButton toolTipLabel={"new proposal"}
-                            label={"Create a new proposal"}
+                            label={"Create new proposal"}
                             onClickEvent={handleAddNew}/>
                         <FileButton onChange={handleUploadZip}
                             accept={".zip"}>
-                            {(props) => <UploadButton
-                            toolTipLabel="select a file from disk to upload"
-                            label={"Import"}
-                            onClick={props.onClick}/>}
-                            </FileButton>
+                            {(props) =>
+                                <UploadButton
+                                    toolTipLabel="select a file from disk to upload"
+                                    label={"Import existing proposal"}
+                                    onClick={props.onClick}
+                                />
+                            }
+                        </FileButton>
                         </AppShell.Section>
                         <AppShell.Section component={ScrollArea}>
                             <ProposalListWrapper

--- a/src/main/webui/src/commonButtons/delete.tsx
+++ b/src/main/webui/src/commonButtons/delete.tsx
@@ -25,7 +25,7 @@ function DeleteButton(props: ClickButtonInterfaceProps): ReactElement {
         >
             <Button
                 rightSection={<IconTrash size={ICON_SIZE}/>}
-                color={"red.5"}
+                color={"red.7"}
                 variant={props.variant ?? "subtle"}
                 onClick={props.onClick ?? props.onClickEvent}
                 disabled={props.disabled}

--- a/src/main/webui/src/commonButtons/export.tsx
+++ b/src/main/webui/src/commonButtons/export.tsx
@@ -1,0 +1,25 @@
+import {ClickButtonInterfaceProps} from "./buttonInterfaceProps.tsx";
+import {ReactElement} from "react";
+import {Button, Tooltip} from "@mantine/core";
+import {CLOSE_DELAY, ICON_SIZE, OPEN_DELAY} from "../constants.tsx";
+import {IconDownload} from "@tabler/icons-react";
+
+export
+function ExportButton(props: ClickButtonInterfaceProps) : ReactElement {
+    return (
+        <Tooltip position={props.toolTipLabelPosition ?? "left"}
+                 label={props.toolTipLabel}
+                 openDelay={OPEN_DELAY}
+                 closeDelay={CLOSE_DELAY}
+        >
+            <Button
+                rightSection={<IconDownload size={ICON_SIZE}/>}
+                color={"blue.7"}
+                variant={props.variant ?? "subtle"}
+                onClick={props.onClick === undefined? props.onClickEvent : props.onClick}
+                disabled={props.disabled}>
+                {props.label === undefined? 'Export' : props.label}
+            </Button>
+        </Tooltip>
+    )
+}

--- a/src/main/webui/src/commonButtons/save.tsx
+++ b/src/main/webui/src/commonButtons/save.tsx
@@ -92,17 +92,17 @@ function SubmitButton(props: BasicButtonInterfaceProps): ReactElement {
  */
 export function SaveButton(props: ClickButtonInterfaceProps): ReactElement {
     return (
-        <Tooltip position={"left"}
+        <Tooltip position={props.toolTipLabelPosition ?? "left"}
                  label={props.toolTipLabel}
                  openDelay={OPEN_DELAY}
-                 closeDelay={CLOSE_DELAY}>
-            <Button rightSection={<IconDeviceFloppy size={ICON_SIZE}/>}
-            color={"violet.5"}
-            variant={"subtle"}
-            onClick={props.onClick === undefined?
-                props.onClickEvent :
-                props.onClick}
-            disabled={props.disabled}>
+                 closeDelay={CLOSE_DELAY}
+        >
+            <Button
+                rightSection={<IconDeviceFloppy size={ICON_SIZE}/>}
+                color={"blue.7"}
+                variant={props.variant ?? "subtle"}
+                onClick={props.onClick === undefined? props.onClickEvent : props.onClick}
+                disabled={props.disabled}>
                 {props.label === undefined? 'Save' : props.label}
             </Button>
         </Tooltip>


### PR DESCRIPTION
I've added a delete proposal button to the Overview Panel. 

I've included some layout and style changes for that page, and added an "export" common button. 

I've had to add a hack to force an App re-render after a proposal deletion. This is to avoid an issue where the recently deleted proposal still displays in the left-hand navbar despite having been removed from the database. 