### PR TITLE
297 title, summary, and kind now use mutations 

### DIFF
--- a/src/main/webui/src/ProposalEditorView/proposal/TitleSummaryKind.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/TitleSummaryKind.tsx
@@ -194,10 +194,10 @@ function TitleSummaryKind() : ReactElement {
                 <Stack>
                     <form onSubmit={handleSubmit}>
                         <Grid>
-                            <Grid.Col span={10}>
+                            <Grid.Col span={{base: 7, md: 8, xl: 10}}>
                                 {TitleInput()}
                             </Grid.Col>
-                            <Grid.Col span={2}>
+                            <Grid.Col span={{base: 5, md: 4, xl: 2}}>
                                 <Space h={"45"}/>
                                 <FormSubmitButton
                                     variant={"filled"}

--- a/src/main/webui/src/ProposalEditorView/proposal/TitleSummaryKind.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/TitleSummaryKind.tsx
@@ -119,7 +119,7 @@ function TitleSummaryKind() : ReactElement {
         return (
             <Stack>
                 <TextInput
-                    label={"Title"}
+                    label={form.isDirty('title') ? "Title (unsaved changes)" : "Title"}
                     name="title"
                     maxLength={MAX_CHARS_FOR_INPUTS}
                     description={"make changes then click update"}
@@ -137,7 +137,7 @@ function TitleSummaryKind() : ReactElement {
                     label={"Summary"}
                     rows={TEXTAREA_MAX_ROWS}
                     maxLength={MAX_CHARS_FOR_INPUTS}
-                    description={"saves as you type"}
+                    description={"saves after a pause in typing"}
                     name="summary"
                     value={summary}
                     onChange={handleSummaryChange}
@@ -150,6 +150,7 @@ function TitleSummaryKind() : ReactElement {
     const KindInput = () : ReactElement => {
         return (
             <Select label={"Kind"}
+                    description={"saves on change"}
                     data={kindData}
                     allowDeselect={false}
                     value={kind}
@@ -204,6 +205,7 @@ function TitleSummaryKind() : ReactElement {
                                     label={"Update Title"}
                                     toolTipLabel={"Save Changes"}
                                     notValidToolTipLabel={"Title must be at least one character"}
+                                    notDirtyToolTipLabel={"Title has not been modified"}
                                 />
                             </Grid.Col>
                         </Grid>

--- a/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
+++ b/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
@@ -36,6 +36,7 @@ export interface BasicButtonInterfaceProps {
  * @param {string} label the text shown next to the buttons icon - defaults to 'save'
  * @param {ButtonVariant} varient one of 'default', 'light', 'subtle', 'filled',
  * 'outline', 'white', 'transparent' - defaults to 'subtle'
+ * @param {string} notValidToolTiplabel optional tool tip when button is disabled due to invalid form values
  */
 export interface FormSubmitButtonInterfaceProps {
     form: UseFormReturnType<any>
@@ -43,6 +44,7 @@ export interface FormSubmitButtonInterfaceProps {
     toolTipLabelPosition?: FloatingPosition
     label?: string
     variant?: ButtonVariant
+    notValidToolTipLabel?: string
 }
 
 /**

--- a/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
+++ b/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
@@ -36,7 +36,8 @@ export interface BasicButtonInterfaceProps {
  * @param {string} label the text shown next to the buttons icon - defaults to 'save'
  * @param {ButtonVariant} varient one of 'default', 'light', 'subtle', 'filled',
  * 'outline', 'white', 'transparent' - defaults to 'subtle'
- * @param {string} notValidToolTiplabel optional tool tip when button is disabled due to invalid form values
+ * @param {string} notValidToolTipLabel optional custom tool tip when button is disabled due to invalid form values
+ * @param {string} notDirtyToolTipLable optional custom text to display when no values have changed in the form
  */
 export interface FormSubmitButtonInterfaceProps {
     form: UseFormReturnType<any>
@@ -45,6 +46,7 @@ export interface FormSubmitButtonInterfaceProps {
     label?: string
     variant?: ButtonVariant
     notValidToolTipLabel?: string
+    notDirtyToolTipLabel?: string
 }
 
 /**

--- a/src/main/webui/src/commonButtons/save.tsx
+++ b/src/main/webui/src/commonButtons/save.tsx
@@ -28,7 +28,7 @@ function FormSubmitButton(props: FormSubmitButtonInterfaceProps): ReactElement {
                 props.form.isValid()?
                     props.form.isDirty()?
                         props.toolTipLabel ?? label
-                        :"No values have changed"
+                        : props.notDirtyToolTipLabel ?? "No values have changed"
                     : props.notValidToolTipLabel ?? "All fields must be complete and valid"
             }
             openDelay={OPEN_DELAY}

--- a/src/main/webui/src/commonButtons/save.tsx
+++ b/src/main/webui/src/commonButtons/save.tsx
@@ -29,7 +29,7 @@ function FormSubmitButton(props: FormSubmitButtonInterfaceProps): ReactElement {
                     props.form.isDirty()?
                         props.toolTipLabel ?? label
                         :"No values have changed"
-                    : "All fields must be complete and valid"
+                    : props.notValidToolTipLabel ?? "All fields must be complete and valid"
             }
             openDelay={OPEN_DELAY}
             closeDelay={CLOSE_DELAY}


### PR DESCRIPTION
Changed the form for title, summary, and kind such that edits to those things now occurs using the mutation functions rather than the "fetch" functions of the generated code.

I have also change the way these things are saved:

- The Title is updated via modifying the text then clicking the "Update Title" button (this avoids having to deal with blank titles if we'd use a debounce instead);
- The Summary uses a debounce function to save the text after the user has paused typing - note then that a summary may be blank but this could be something detected by server side validation before submission;
- The Kind is saved on change.

 I have made this clear by adding descriptions to each input. I have also added optional customisable tool tip labels for when the "Update Title" button is disabled either due to an invalid Title or when the Title has yet to be modified. Also, the label for the Title input shows a description for when you have unsaved changes. 