### PR TITLE
change 'fetch' calls to 'mutation' calls to update justifications

### DIFF
--- a/src/main/webui/src/ProposalEditorView/justifications/JustificationsPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/JustificationsPanel.tsx
@@ -1,20 +1,12 @@
-import {ReactElement, useEffect, useState} from "react";
+import {ReactElement} from "react";
 import {useParams} from "react-router-dom";
 import {
-    fetchJustificationsResourceGetJustification,
+    useJustificationsResourceGetJustification,
 } from "src/generated/proposalToolComponents.ts";
-import {Justification} from "src/generated/proposalToolSchemas.ts";
 import JustificationsTable from "./justifications.table.tsx";
 import {EditorPanelHeader, PanelFrame} from "../../commonPanel/appearance.tsx";
 import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
-import {notifyError} from "../../commonPanel/notifications.tsx";
-import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-
-//no need to use an array, only two "kinds" of Justification 'scientific' and 'technical'
-export type JustificationKinds = {
-    scientific: Justification,
-    technical: Justification
-}
+import {Loader} from "@mantine/core";
 
 export type WhichJustification = 'scientific' | 'technical';
 
@@ -22,42 +14,24 @@ export default function JustificationsPanel() : ReactElement {
 
     const { selectedProposalCode } = useParams();
 
-    const [isChanged, setIsChanged] = useState<boolean>(false);
-
-    const [justifications, setJustifications] = useState<JustificationKinds>({
-        scientific: {text: "", format: undefined},
-        technical: {text: "", format: undefined}
+    const scientificJustification = useJustificationsResourceGetJustification({
+        pathParams: {proposalCode: Number(selectedProposalCode), which: 'scientific'}
     })
 
-    useEffect(() => {
-        fetchJustificationsResourceGetJustification({
-            pathParams: {proposalCode: Number(selectedProposalCode), which: "scientific"}
-        })
-            .then((scientific) => {
-                fetchJustificationsResourceGetJustification({
-                    pathParams: {proposalCode: Number(selectedProposalCode), which: "technical"}
-                })
-                    .then ((technical) => {
-                        setJustifications({scientific: scientific, technical: technical})
-                    })
-                    .catch((error) =>
-                        notifyError("Fetch fail 'technical", getErrorMessage(error))
-                    )
-            })
-            .catch(
-                (error) =>
-                    notifyError("Fetch fail 'scientific", getErrorMessage(error))
-            )
-    }, [isChanged]);
+    const technicalJustification = useJustificationsResourceGetJustification({
+        pathParams: {proposalCode: Number(selectedProposalCode), which: 'technical'}
+    })
 
     return (
         <PanelFrame>
             <EditorPanelHeader proposalCode={Number(selectedProposalCode)} panelHeading={"Justifications"} />
             <ContextualHelpButton messageId="MaintJustList" />
-            <JustificationsTable
-                justifications={justifications}
-                onChange={() => setIsChanged(!isChanged)}
-            />
+            {
+                scientificJustification.isLoading || technicalJustification.isLoading ?
+                    <Loader /> : <JustificationsTable
+                        scientific={scientificJustification.data!}
+                        technical={technicalJustification.data!} />
+            }
         </PanelFrame>
     )
 }

--- a/src/main/webui/src/ProposalEditorView/justifications/edit.modal.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/edit.modal.tsx
@@ -44,7 +44,6 @@ export default function JustificationsEditModal(justificationProps : Justificati
         ...justificationProps,
         closeModal: () =>{
             close();
-            justificationProps.onChange(); //trigger re-fetch of justifications, something may have changed
         }}
 
     return (

--- a/src/main/webui/src/ProposalEditorView/justifications/justifications.table.tsx
+++ b/src/main/webui/src/ProposalEditorView/justifications/justifications.table.tsx
@@ -1,5 +1,5 @@
 import {ReactElement} from "react";
-import {JustificationKinds, WhichJustification} from "./JustificationsPanel.tsx";
+import { WhichJustification} from "./JustificationsPanel.tsx";
 import {Justification} from "src/generated/proposalToolSchemas.ts";
 import {Table} from "@mantine/core";
 import JustificationsEditModal from "./edit.modal.tsx";
@@ -7,7 +7,6 @@ import JustificationsEditModal from "./edit.modal.tsx";
 export type JustificationProps = {
     which : WhichJustification,
     justification: Justification,
-    onChange: () => void,
     closeModal?: () => void
 }
 
@@ -17,8 +16,8 @@ function WordCount(text: string): number {
         .length;
 }
 
-export default function JustificationsTable(
-    {justifications, onChange}: {justifications: JustificationKinds, onChange: () => void})
+export default
+function JustificationsTable(justifications: {scientific: Justification, technical: Justification})
     : ReactElement {
 
     const justificationsHeader = () : ReactElement => {
@@ -47,7 +46,6 @@ export default function JustificationsTable(
                         <JustificationsEditModal
                             which={'scientific'}
                             justification={justifications.scientific}
-                            onChange={onChange}
                         />
                     </Table.Td>
                 </Table.Tr>
@@ -59,7 +57,6 @@ export default function JustificationsTable(
                         <JustificationsEditModal
                             which={'technical'}
                             justification={justifications.technical}
-                            onChange={onChange}
                         />
                     </Table.Td>
                 </Table.Tr>


### PR DESCRIPTION
Functions have been changed from 'fetch' to 'mutations'. Notice that this has significantly reduced the complexity of the code and removed the visual "twitch" when switching justification formats. 