### PR TITLE
Landing page withdraw submitted proposal now uses mutation

### DIFF
--- a/src/main/webui/src/ProposalEditorView/landingPage/proposalsAccordion.tsx
+++ b/src/main/webui/src/ProposalEditorView/landingPage/proposalsAccordion.tsx
@@ -2,14 +2,12 @@ import {ReactElement, useEffect, useState} from "react";
 import {Accordion, Button, Fieldset, Grid, Group, ScrollArea, Stack, Table, Text, Tooltip} from "@mantine/core";
 import {ObjectIdentifier, ProposalSynopsis} from "../../generated/proposalToolSchemas.ts";
 import {
-    fetchSubmittedProposalResourceGetSubmittedProposals,
-    fetchUserProposalsSubmittedWithdrawProposal,
-    UserProposalsSubmittedWithdrawProposalVariables
+    useSubmittedProposalResourceGetSubmittedProposals,
+    useUserProposalsSubmittedWithdrawProposal
 } from "../../generated/proposalToolComponents.ts";
 import {modals} from "@mantine/modals";
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {useToken} from "../../App2.tsx";
 
 type SubmissionDetail = {
     cycleName: string,
@@ -99,30 +97,31 @@ function CycleSubmissionDetail(props: {
     investigatorName: string,
     proposalTitle: string
 }):  ReactElement {
-    const token = useToken();
-
     const [submissionDetail, setSubmissionDetail] =
         useState<SubmissionDetail | null> (null);
 
-    useEffect(() => {
-        fetchSubmittedProposalResourceGetSubmittedProposals({
+    const submissionMutation =
+        useUserProposalsSubmittedWithdrawProposal();
+
+    const submittedProposals =
+        useSubmittedProposalResourceGetSubmittedProposals({
             pathParams: {cycleCode: props.cycle.dbid!},
             //find exact proposal title and investigator name
             queryParams: {title: props.proposalTitle, investigatorName: props.investigatorName}
         })
-            .then((data: ObjectIdentifier[]) => {
-                if (data.length > 0) {
-                    setSubmissionDetail(
-                        {
-                            cycleName: props.cycle.name!,
-                            //assume a distinct proposal is submitted once only to a particular cycle
-                            submissionDate: data.at(0)!.code!,
-                            submittedProposalId: data.at(0)!.dbid!
-                        }
-                    )
+
+    useEffect(() => {
+        if (submittedProposals.status === 'success' && submittedProposals.data.length > 0) {
+            setSubmissionDetail(
+                {
+                    cycleName: props.cycle.name!,
+                    //assume a distinct proposal is submitted once only to a particular cycle
+                    submissionDate: submittedProposals.data.at(0)!.code!,
+                    submittedProposalId: submittedProposals.data.at(0)!.dbid!
                 }
-            })
-    }, [])
+            )
+        }
+    }, [submittedProposals.status])
 
     const confirmWithdrawal = () => {
         modals.openConfirmModal({
@@ -147,18 +146,20 @@ function CycleSubmissionDetail(props: {
     }
 
     const handleWithdrawal = () => {
-        const vars:UserProposalsSubmittedWithdrawProposalVariables = {
-                headers: {authorization: token ? `Bearer ${token}` : undefined},
-                pathParams: {submittedProposalId: submissionDetail?.submittedProposalId!},
-                queryParams: {cycleId: props.cycle.dbid!}
-        };
-        fetchUserProposalsSubmittedWithdrawProposal(vars)
-            .then(() => setSubmissionDetail(null))
-            .then(() => notifySuccess(
-                "Withdrawn",
-                "'" + props.proposalTitle + "' has been withdrawn from '" + props.cycle.name + "'."
-            ))
-            .catch(error => notifyError("Withdraw Fail", getErrorMessage(error)));
+        submissionMutation.mutate({
+            pathParams: {submittedProposalId: submissionDetail?.submittedProposalId!},
+            queryParams: {cycleId: props.cycle.dbid!}
+        }, {
+            onSuccess: () => {
+                setSubmissionDetail(null);
+                notifySuccess(
+                    "Withdrawn",
+                    "'" + props.proposalTitle + "' has been withdrawn from '" + props.cycle.name + "'."
+                )
+            },
+            onError: (error) =>
+                notifyError("Withdraw Fail", getErrorMessage(error))
+        })
     }
 
     return(

--- a/src/main/webui/src/generated/proposalToolComponents.ts
+++ b/src/main/webui/src/generated/proposalToolComponents.ts
@@ -3996,6 +3996,69 @@ export const useAllocatedProposalResourceGetAllocatedProposal = <
   });
 };
 
+export type AllocatedProposalResourceWithdrawAllocatedProposalPathParams = {
+  /**
+   * @format int64
+   */
+  allocatedId: number;
+  /**
+   * @format int64
+   */
+  cycleCode: number;
+};
+
+export type AllocatedProposalResourceWithdrawAllocatedProposalError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type AllocatedProposalResourceWithdrawAllocatedProposalVariables = {
+  pathParams: AllocatedProposalResourceWithdrawAllocatedProposalPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchAllocatedProposalResourceWithdrawAllocatedProposal = (
+  variables: AllocatedProposalResourceWithdrawAllocatedProposalVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    AllocatedProposalResourceWithdrawAllocatedProposalError,
+    undefined,
+    {},
+    {},
+    AllocatedProposalResourceWithdrawAllocatedProposalPathParams
+  >({
+    url: "/pst/api/proposalCycles/{cycleCode}/allocatedProposals/{allocatedId}",
+    method: "delete",
+    ...variables,
+    signal,
+  });
+
+export const useAllocatedProposalResourceWithdrawAllocatedProposal = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      AllocatedProposalResourceWithdrawAllocatedProposalError,
+      AllocatedProposalResourceWithdrawAllocatedProposalVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    undefined,
+    AllocatedProposalResourceWithdrawAllocatedProposalError,
+    AllocatedProposalResourceWithdrawAllocatedProposalVariables
+  >({
+    mutationFn: (
+      variables: AllocatedProposalResourceWithdrawAllocatedProposalVariables,
+    ) =>
+      fetchAllocatedProposalResourceWithdrawAllocatedProposal({
+        ...fetcherOptions,
+        ...variables,
+      }),
+    ...options,
+  });
+};
+
 export type AllocatedBlockResourceGetAllocatedBlocksPathParams = {
   /**
    * @format int64
@@ -8670,66 +8733,6 @@ export const useJustificationsResourceGetLatexResourceFiles = <
   });
 };
 
-export type JustificationsResourceReplaceLatexResourceFilePathParams = {
-  /**
-   * @format int64
-   */
-  proposalCode: number;
-  which: string;
-};
-
-export type JustificationsResourceReplaceLatexResourceFileError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type JustificationsResourceReplaceLatexResourceFileVariables = {
-  pathParams: JustificationsResourceReplaceLatexResourceFilePathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchJustificationsResourceReplaceLatexResourceFile = (
-  variables: JustificationsResourceReplaceLatexResourceFileVariables,
-  signal?: AbortSignal,
-) =>
-  proposalToolFetch<
-    undefined,
-    JustificationsResourceReplaceLatexResourceFileError,
-    undefined,
-    {},
-    {},
-    JustificationsResourceReplaceLatexResourceFilePathParams
-  >({
-    url: "/pst/api/proposals/{proposalCode}/justifications/{which}/latexResource",
-    method: "put",
-    ...variables,
-    signal,
-  });
-
-export const useJustificationsResourceReplaceLatexResourceFile = (
-  options?: Omit<
-    reactQuery.UseMutationOptions<
-      undefined,
-      JustificationsResourceReplaceLatexResourceFileError,
-      JustificationsResourceReplaceLatexResourceFileVariables
-    >,
-    "mutationFn"
-  >,
-) => {
-  const { fetcherOptions } = useProposalToolContext();
-  return reactQuery.useMutation<
-    undefined,
-    JustificationsResourceReplaceLatexResourceFileError,
-    JustificationsResourceReplaceLatexResourceFileVariables
-  >({
-    mutationFn: (
-      variables: JustificationsResourceReplaceLatexResourceFileVariables,
-    ) =>
-      fetchJustificationsResourceReplaceLatexResourceFile({
-        ...fetcherOptions,
-        ...variables,
-      }),
-    ...options,
-  });
-};
-
 export type JustificationsResourceAddLatexResourceFilePathParams = {
   /**
    * @format int64
@@ -10148,74 +10151,6 @@ export const useSupportingDocumentResourceGetSupportingDocument = <
   });
 };
 
-export type SupportingDocumentResourceReplaceSupportingDocumentPathParams = {
-  /**
-   * @format int64
-   */
-  id: number;
-  /**
-   * @format int64
-   */
-  proposalCode: number;
-};
-
-export type SupportingDocumentResourceReplaceSupportingDocumentError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type SupportingDocumentResourceReplaceSupportingDocumentRequestBody = {
-  document?: Schemas.UploadItemSchema;
-};
-
-export type SupportingDocumentResourceReplaceSupportingDocumentVariables = {
-  body?: SupportingDocumentResourceReplaceSupportingDocumentRequestBody;
-  pathParams: SupportingDocumentResourceReplaceSupportingDocumentPathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchSupportingDocumentResourceReplaceSupportingDocument = (
-  variables: SupportingDocumentResourceReplaceSupportingDocumentVariables,
-  signal?: AbortSignal,
-) =>
-  proposalToolFetch<
-    undefined,
-    SupportingDocumentResourceReplaceSupportingDocumentError,
-    SupportingDocumentResourceReplaceSupportingDocumentRequestBody,
-    {},
-    {},
-    SupportingDocumentResourceReplaceSupportingDocumentPathParams
-  >({
-    url: "/pst/api/proposals/{proposalCode}/supportingDocuments/{id}",
-    method: "put",
-    ...variables,
-    signal,
-  });
-
-export const useSupportingDocumentResourceReplaceSupportingDocument = (
-  options?: Omit<
-    reactQuery.UseMutationOptions<
-      undefined,
-      SupportingDocumentResourceReplaceSupportingDocumentError,
-      SupportingDocumentResourceReplaceSupportingDocumentVariables
-    >,
-    "mutationFn"
-  >,
-) => {
-  const { fetcherOptions } = useProposalToolContext();
-  return reactQuery.useMutation<
-    undefined,
-    SupportingDocumentResourceReplaceSupportingDocumentError,
-    SupportingDocumentResourceReplaceSupportingDocumentVariables
-  >({
-    mutationFn: (
-      variables: SupportingDocumentResourceReplaceSupportingDocumentVariables,
-    ) =>
-      fetchSupportingDocumentResourceReplaceSupportingDocument({
-        ...fetcherOptions,
-        ...variables,
-      }),
-    ...options,
-  });
-};
-
 export type SupportingDocumentResourceRemoveSupportingDocumentPathParams = {
   /**
    * @format int64
@@ -11625,41 +11560,33 @@ export const fetchUserProposalsSubmittedWithdrawProposal = (
     UserProposalsSubmittedWithdrawProposalPathParams
   >({
     url: "/pst/api/proposalsSubmitted/{submittedProposalId}/withdraw",
-    method: "get",
+    method: "delete",
     ...variables,
     signal,
   });
 
-export const useUserProposalsSubmittedWithdrawProposal = <TData = undefined,>(
-  variables: UserProposalsSubmittedWithdrawProposalVariables,
+export const useUserProposalsSubmittedWithdrawProposal = (
   options?: Omit<
-    reactQuery.UseQueryOptions<
+    reactQuery.UseMutationOptions<
       undefined,
       UserProposalsSubmittedWithdrawProposalError,
-      TData
+      UserProposalsSubmittedWithdrawProposalVariables
     >,
-    "queryKey" | "queryFn" | "initialData"
+    "mutationFn"
   >,
 ) => {
-  const { fetcherOptions, queryOptions, queryKeyFn } =
-    useProposalToolContext(options);
-  return reactQuery.useQuery<
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
     undefined,
     UserProposalsSubmittedWithdrawProposalError,
-    TData
+    UserProposalsSubmittedWithdrawProposalVariables
   >({
-    queryKey: queryKeyFn({
-      path: "/pst/api/proposalsSubmitted/{submittedProposalId}/withdraw",
-      operationId: "userProposalsSubmittedWithdrawProposal",
-      variables,
-    }),
-    queryFn: ({ signal }) =>
-      fetchUserProposalsSubmittedWithdrawProposal(
-        { ...fetcherOptions, ...variables },
-        signal,
-      ),
+    mutationFn: (variables: UserProposalsSubmittedWithdrawProposalVariables) =>
+      fetchUserProposalsSubmittedWithdrawProposal({
+        ...fetcherOptions,
+        ...variables,
+      }),
     ...options,
-    ...queryOptions,
   });
 };
 
@@ -12911,11 +12838,6 @@ export type QueryOperation =
       path: "/pst/api/proposalsSubmitted";
       operationId: "userProposalsSubmittedGetProposalsSubmitted";
       variables: UserProposalsSubmittedGetProposalsSubmittedVariables;
-    }
-  | {
-      path: "/pst/api/proposalsSubmitted/{submittedProposalId}/withdraw";
-      operationId: "userProposalsSubmittedWithdrawProposal";
-      variables: UserProposalsSubmittedWithdrawProposalVariables;
     }
   | {
       path: "/pst/api/resourceTypes";

--- a/src/main/webui/src/generated/proposalToolSchemas.ts
+++ b/src/main/webui/src/generated/proposalToolSchemas.ts
@@ -570,13 +570,13 @@ export type GenericCoordSpace = {
  */
 export type GenericFrame = {
   /**
-   * RefLocation defines the origin of the spatial coordinate space. This location is represented either by a standard reference position (for which the absolute location in phase space is known by definition), or a specified point in another Spatial frame. This object is used as the origin of the SpaceFrame here, but also to specify the Spatial Reference Position (refPosition) associated with other domain Frames. For example, in the Time domain, the Spatial Reference Position indicates that the 'time' values are the time that the 'event' occured at that location, which might be different from the detector location.
-   */
-  refPosition?: RefLocation;
-  /**
    * A planetary ephemeris MAY be provided, and SHOULD be provided whenever appropriate, to indicate which solar system ephemeris was used. If needed, but not provided, it is assumed to be 'DE405'
    */
   planetaryEphem?: string;
+  /**
+   * RefLocation defines the origin of the spatial coordinate space. This location is represented either by a standard reference position (for which the absolute location in phase space is known by definition), or a specified point in another Spatial frame. This object is used as the origin of the SpaceFrame here, but also to specify the Spatial Reference Position (refPosition) associated with other domain Frames. For example, in the Time domain, the Spatial Reference Position indicates that the 'time' values are the time that the 'event' occured at that location, which might be different from the detector location.
+   */
+  refPosition?: RefLocation;
 };
 
 /**
@@ -1488,10 +1488,6 @@ export type SolarSystemTarget = {
 export type SpaceFrame = {
   "@type": string; // coords:SpaceFrame
   /**
-   * RefLocation defines the origin of the spatial coordinate space. This location is represented either by a standard reference position (for which the absolute location in phase space is known by definition), or a specified point in another Spatial frame. This object is used as the origin of the SpaceFrame here, but also to specify the Spatial Reference Position (refPosition) associated with other domain Frames. For example, in the Time domain, the Spatial Reference Position indicates that the 'time' values are the time that the 'event' occured at that location, which might be different from the detector location.
-   */
-  refPosition?: RefLocation;
-  /**
    * The spatial reference frame. Values MUST be selected from the controlled vocabulary at the given URL.
    */
   spaceRefFrame?: string;
@@ -1503,6 +1499,10 @@ export type SpaceFrame = {
    * Ephemeris file for solar system objects SHOULD be specified whenever relevant.
    */
   planetaryEphem?: string;
+  /**
+   * RefLocation defines the origin of the spatial coordinate space. This location is represented either by a standard reference position (for which the absolute location in phase space is known by definition), or a specified point in another Spatial frame. This object is used as the origin of the SpaceFrame here, but also to specify the Spatial Reference Position (refPosition) associated with other domain Frames. For example, in the Time domain, the Spatial Reference Position indicates that the 'time' values are the time that the 'event' occured at that location, which might be different from the detector location.
+   */
+  refPosition?: RefLocation;
 };
 
 /**
@@ -1838,13 +1838,13 @@ export type TextFormats = "latex" | "rst" | "asciidoc";
  */
 export type TimeFrame = {
   /**
-   * RefLocation defines the origin of the spatial coordinate space. This location is represented either by a standard reference position (for which the absolute location in phase space is known by definition), or a specified point in another Spatial frame. This object is used as the origin of the SpaceFrame here, but also to specify the Spatial Reference Position (refPosition) associated with other domain Frames. For example, in the Time domain, the Spatial Reference Position indicates that the 'time' values are the time that the 'event' occured at that location, which might be different from the detector location.
-   */
-  refPosition?: RefLocation;
-  /**
    * The time scale sets the reference frame. The value MUST be selected from the controlled vocabulary at the given URL.
    */
   timescale?: string;
+  /**
+   * RefLocation defines the origin of the spatial coordinate space. This location is represented either by a standard reference position (for which the absolute location in phase space is known by definition), or a specified point in another Spatial frame. This object is used as the origin of the SpaceFrame here, but also to specify the Spatial Reference Position (refPosition) associated with other domain Frames. For example, in the Time domain, the Spatial Reference Position indicates that the 'time' values are the time that the 'event' occured at that location, which might be different from the detector location.
+   */
+  refPosition?: RefLocation;
   /**
    * RefLocation defines the origin of the spatial coordinate space. This location is represented either by a standard reference position (for which the absolute location in phase space is known by definition), or a specified point in another Spatial frame. This object is used as the origin of the SpaceFrame here, but also to specify the Spatial Reference Position (refPosition) associated with other domain Frames. For example, in the Time domain, the Spatial Reference Position indicates that the 'time' values are the time that the 'event' occured at that location, which might be different from the detector location.
    */


### PR DESCRIPTION
I got distracted and did this on the branch I used for justifications. 

Anyway, Landing page now uses a mutation call to withdraw a previously submitted proposal. I had to make a change to the API as the withdrawal call was wrongly annotated with 'GET' causing the code generator to create a query hook for the withdrawal function in typescript. I've changed it to 'DELETE' such that the code generator produces a mutation hook instead. 