### PR TITLE
318 observations change to mutations

### DIFF
--- a/src/main/webui/src/ProposalEditorView/observationFields/observationFieldsTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/observationFieldsTable.tsx
@@ -2,9 +2,8 @@ import {ReactElement} from "react";
 import {Group, Table, Text} from "@mantine/core";
 import {useParams} from "react-router-dom";
 import {
-    fetchProposalResourceRemoveField,
     useProposalResourceGetField,
-    useProposalResourceGetFields
+    useProposalResourceGetFields, useProposalResourceRemoveField
 } from "../../generated/proposalToolComponents.ts";
 import ObservationFieldModal from "./observationFields.modal.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
@@ -32,6 +31,8 @@ function ObservationFieldsRow(props: ObservationFieldRowProps): ReactElement {
 
     const queryClient = useQueryClient();
 
+    const removeFieldMutation = useProposalResourceRemoveField()
+
     if (field.isError) {
         return (
             <Table.Tr key={props.fieldId}><Table.Td>Error: {getErrorMessage(field.error)}</Table.Td>
@@ -48,17 +49,20 @@ function ObservationFieldsRow(props: ObservationFieldRowProps): ReactElement {
     }
 
     const handleDelete = () => {
-        fetchProposalResourceRemoveField({
+        removeFieldMutation.mutate({
             pathParams: {
                 proposalCode: props.proposalCode,
                 fieldId: props.fieldId
             }
+        }, {
+            onSuccess: () => {
+                queryClient.invalidateQueries().then();
+                notifySuccess("Deleted Successfully",
+                    "the field has been removed");
+            },
+            onError: (error) =>
+                notifyError("Deletion Failed", getErrorMessage(error))
         })
-            .then(() => queryClient.invalidateQueries())
-            .then(() => notifySuccess("Deleted Successfully",
-                "the field has been removed"))
-            .catch(error => notifyError("Deletion Failed",
-                getErrorMessage(error)))
     }
 
     const confirmDeletion = () => modals.openConfirmModal({

--- a/src/main/webui/src/ProposalEditorView/observations/targetType.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/targetType.form.tsx
@@ -1,6 +1,7 @@
 import {
-    fetchProposalResourceGetFields,
-    useProposalResourceGetTargets, useTechnicalGoalResourceGetTechnicalGoals,
+    useProposalResourceGetFields,
+    useProposalResourceGetTargets,
+    useTechnicalGoalResourceGetTechnicalGoals,
 } from "src/generated/proposalToolComponents.ts";
 import {
     Container,
@@ -22,7 +23,6 @@ import { TargetTable } from '../targets/TargetTable.tsx';
 import { TechnicalGoalsTable } from '../technicalGoals/technicalGoalTable.tsx';
 import {notifyError} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ObjectIdentifier} from "../../generated/proposalToolSchemas.ts";
 
 /**
  * the entrance to building the target part of the edit panel.
@@ -37,6 +37,7 @@ export default function TargetTypeForm (
     const { selectedProposalCode} = useParams();
     const theme = useMantineTheme();
 
+    //for the observation fields select input
     const [fieldsData, setFieldsData]
         = useState<{value: string, label: string}[]>([])
 
@@ -57,21 +58,20 @@ export default function TargetTypeForm (
                 pathParams: {proposalCode: Number(selectedProposalCode)}
             });
 
-    useEffect(() => {
-        fetchProposalResourceGetFields({
+    const observationFields =
+        useProposalResourceGetFields({
             pathParams: {proposalCode: Number(selectedProposalCode)}
         })
-            .then((data: ObjectIdentifier[]) => {
-                setFieldsData(
-                    data?.map(field => (
-                        {value: String(field.dbid!), label: field.name!}
-                    ))
-                )
-            })
-            .catch(error => {console.error(error); notifyError("Error loading fields",
-                "cause: " + getErrorMessage(error))}
+
+    useEffect(() => {
+        if (observationFields.status === 'success') {
+            setFieldsData(
+                observationFields.data.map(field => (
+                    {value: String(field.dbid!), label: field.name!}
+                ))
             )
-    }, []);
+        }
+    }, [observationFields.status]);
 
     /**
      * generates the html for the observation type. Notice, disabled if editing

--- a/src/main/webui/src/queryKeyProposals.tsx
+++ b/src/main/webui/src/queryKeyProposals.tsx
@@ -1,0 +1,16 @@
+import {QueryKey} from "@tanstack/react-query";
+
+/**
+ * Convenience function to return a specific QueryKey to use in 'queryClient.invalidateQueries()'
+ * when mutating a proposal
+ *
+ * @param props object containing the proposal ID, the child name e.g., 'observations',
+ * and the child's ID
+ */
+export
+function queryKeyProposals(
+    props: {proposalId: number, childName: string, childId: number}
+): QueryKey
+{
+    return ["pst", "api", "proposals", props.proposalId, props.childName, props.childId];
+}


### PR DESCRIPTION
The observations now use mutations to create, delete, and edit observations in the app. I've also done the same for observation fields. In the process I've also made a convenience function to return specific query keys for proposals, and used this when invalidating queries for observations. 