### PR TITLE
324 change remaining functionality in proposal to mutations

### DIFF
--- a/src/main/webui/public/contextualHelpMessages.jsx
+++ b/src/main/webui/public/contextualHelpMessages.jsx
@@ -14,19 +14,18 @@ export const contextualHelpMessages = [
 , {
   id: "Overview-eng",
   message: " "
-          + " An overview of the selected proposal is shown below. You can choose another by clicking its dropdown button in the list."
-          + " You can maintain a component by clicking one of the menuitems, eg Title, Summary, etc."
+          + " An overview of the selected proposal is shown below."
+          + " You may 'Export' this proposal, which provides a downloaded zip file containing this proposal as JSON, any supporting documents you may have uploaded, and a screen shot of this overview."
+          + " You can 'Clone' this proposal, which will create a deep copy as a new proposal."
+          + " If you've decided that this proposal is no longer worth pursuing then you may 'Delete' it."
+          + " This will remove this proposal permanently."
 }
 , {
   id: "CreaProp-eng",
   message: " "
-       + " You must provide a title and a summary."
-       + " Once at least they have been entered, you can save immediately by clicking the Save button following the summary field,"
-       + " and come back later, or cancel and return with the Cancel button."
-       + " Or you can continue with the remaining fields"
-       + " indicating the kind of proposal and providing the scientific and technical justifications."
-       + " You have the option to provide your justification in LaTeX, RST or ASCII format."
-       + " Save your changes with the Save button at bottom right, or cancel and return without saving by clicking the Cancel button."
+       + " You must provide a title and a summary for your new proposal, and select it's 'Kind'."
+       + " After they have been entered, you can create the new proposal by clicking the Save button."
+       + " You may cancel this action with the Cancel button, which will take you back to the landing page."
 }
 , {
   id: "MaintTitle-eng",
@@ -77,7 +76,8 @@ export const contextualHelpMessages = [
 , {
   id: "MaintTargList-eng",
   message: " Add a new Target by clicking the Add button at bottom right of the list."
-    + " Remove a Target by clicking the Delete button in its row. (You can't delete a target that is in use.)"
+    + " Remove a Target by clicking the Delete button in its row."
+    + " Notice that you cannot delete a target that is in use by an 'Observation' (you must first delete the 'Observation)."
 }
 , {
   id: "MaintTarg-eng",

--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -3,7 +3,7 @@ import {
     useContext,
     ReactElement,
     SyntheticEvent,
-    Context, StrictMode, useReducer
+    Context, StrictMode
 } from 'react';
 import {
     QueryClient,
@@ -135,10 +135,6 @@ function App2(): ReactElement {
 
     const GRAY = theme.colors.gray[6];
 
-    // hack to force the left-hand navbar to update after proposal deletion in Overview panel
-    // more precisely, when called, "forceUpdate" will make the entire App rerender - use sparingly!!
-    const [,forceUpdate] = useReducer(x => x + 1, 0);
-
     // the paths to route to.
     const router = createBrowserRouter(
         [
@@ -223,8 +219,7 @@ function App2(): ReactElement {
                     },
                     {
                         path: "proposal/:selectedProposalCode",
-                        //'forceUpdate' is called following a proposal deletion in Overview panel
-                        element: <OverviewPanel forceUpdate={forceUpdate}/>,
+                        element: <OverviewPanel/>,
                         errorElement: <ErrorPage />,
                     },
                     {

--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -3,7 +3,7 @@ import {
     useContext,
     ReactElement,
     SyntheticEvent,
-    Context, StrictMode
+    Context, StrictMode, useReducer
 } from 'react';
 import {
     QueryClient,
@@ -133,6 +133,9 @@ function App2(): ReactElement {
     const theme = useMantineTheme();
     const {colorScheme} = useMantineColorScheme();
 
+    //this work around is used when deleting a proposal
+    const [,forceUpdate] = useReducer(x => x + 1, 0);
+
     const GRAY = theme.colors.gray[6];
 
     // the paths to route to.
@@ -219,7 +222,7 @@ function App2(): ReactElement {
                     },
                     {
                         path: "proposal/:selectedProposalCode",
-                        element: <OverviewPanel/>,
+                        element: <OverviewPanel forceUpdate={forceUpdate}/>,
                         errorElement: <ErrorPage />,
                     },
                     {

--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -7,9 +7,9 @@ import {
 } from 'react';
 import {
     QueryClient,
-    QueryClientProvider,
+    QueryClientProvider, useQueryClient,
 } from '@tanstack/react-query';
-import { Person} from "./generated/proposalToolSchemas.ts";
+import {ObservingProposal, Person} from "./generated/proposalToolSchemas.ts";
 import OverviewPanel from "./ProposalEditorView/proposal/Overview.tsx";
 import NewProposalPanel from './ProposalEditorView/proposal/New.tsx';
 import InvestigatorsPanel from "./ProposalEditorView/investigators/List.tsx";
@@ -49,11 +49,11 @@ import AddButton from './commonButtons/add';
 import DatabaseSearchButton from './commonButtons/databaseSearch';
 //import {ContextualHelpButton} from "./commonButtons/contextualHelp.tsx"
 import {
-    APP_HEADER_HEIGHT, CLOSE_DELAY, ICON_SIZE,
+    APP_HEADER_HEIGHT, CLOSE_DELAY, ICON_SIZE, JSON_FILE_NAME,
     NAV_BAR_DEFAULT_WIDTH, NAV_BAR_LARGE_WIDTH,
     NAV_BAR_MEDIUM_WIDTH, OPEN_DELAY,
 } from './constants';
-import { handleUploadZip } from './ProposalEditorView/proposal/UploadProposal';
+import {SendToImportAPI} from './ProposalEditorView/proposal/UploadProposal';
 import UploadButton from './commonButtons/upload';
 import AdminPanel from "./admin/adminPanel";
 import JustificationsPanel from "./ProposalEditorView/justifications/JustificationsPanel";
@@ -76,6 +76,8 @@ import {PanelFrame} from "./commonPanel/appearance.tsx";
 import TacCycles from "./ProposalManagerView/landingPage/tacCycles.tsx";
 import EditorLandingPage from "./ProposalEditorView/landingPage/editorLandingPage.tsx";
 import TitleSummaryKind from "./ProposalEditorView/proposal/TitleSummaryKind.tsx";
+import {notifyError} from "./commonPanel/notifications.tsx";
+import JSZip from "jszip";
 
 /**
  * defines the user context type.
@@ -300,6 +302,8 @@ function App2(): ReactElement {
      */
     function PSTEditor(): ReactElement {
         const proposalContext = useContext(ProposalContext);
+        const authToken = useToken();
+        const queryClient = useQueryClient();
         const [opened, {toggle}] = useDisclosure();
         const navigate = useNavigate();
         // acquire the state setters for proposal title and investigator name.
@@ -329,6 +333,49 @@ function App2(): ReactElement {
             event.preventDefault();
             navigate("/");
         }
+
+        /**
+         * Handles looking up a file and uploading it to the system.
+         * @param {File} chosenFile the zip file containing a json representation
+         * of the proposal and any supporting documents.
+         */
+        const handleUploadZip =
+            async (chosenFile: File | null) => {
+                // check for no file.
+                if (chosenFile === null) {
+                    notifyError("Upload failed", "There was no file to upload")
+                }
+
+                // all simple checks done. Time to verify the internals of the zip.
+                if (chosenFile !== null) {
+                    JSZip.loadAsync(chosenFile).then(function (zip) {
+                        // check the json file exists.
+                        if (!Object.keys(zip.files).includes(JSON_FILE_NAME)) {
+                            notifyError("Upload failed",
+                                "There was no file called '"+JSON_FILE_NAME+"' within the zip")
+                        }
+
+                        // extract json data to import proposal definition.
+                        zip.files[JSON_FILE_NAME].async('text').then(function (fileData) {
+                            const jsonObject: ObservingProposal = JSON.parse(fileData)
+                            // ensure not undefined
+                            if (jsonObject) {
+                                SendToImportAPI(jsonObject, zip, authToken, queryClient);
+                            } else {
+                                notifyError("Upload failed", "The JSON file failed to load correctly")
+                            }
+                        })
+                            .catch(() => {
+                                console.log("Unable to extract " + JSON_FILE_NAME + " from zip file");
+                                notifyError("Upload failed",
+                                    "Unable to extract " + JSON_FILE_NAME + " from zip file");
+                            })
+                    })
+                }
+            }
+
+
+
 
         /*
         DJW:
@@ -429,8 +476,10 @@ function App2(): ReactElement {
                         <AddButton toolTipLabel={"new proposal"}
                             label={"Create new proposal"}
                             onClickEvent={handleAddNew}/>
-                        <FileButton onChange={handleUploadZip}
-                            accept={".zip"}>
+                        <FileButton
+                            onChange={handleUploadZip}
+                            accept={".zip"}
+                        >
                             {(props) =>
                                 <UploadButton
                                     toolTipLabel="select a file from disk to upload"

--- a/src/main/webui/src/ProposalEditorView/proposal/Overview.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Overview.tsx
@@ -584,12 +584,12 @@ function OverviewPanel(props: {forceUpdate: () => void}): ReactElement {
         cloneProposalMutation.mutate({
             pathParams: {proposalCode: Number(selectedProposalCode)}
         }, {
-            onSuccess: () => {
+            onSuccess: (data) => {
                 queryClient.invalidateQueries({
                     queryKey: ['pst', 'api', 'proposals']
                 }).then(() =>
                     notifySuccess("Clone Proposal Successful",
-                        "you should now change the title of the cloned proposal to something more meaningful")
+                        proposalsData?.title + " copied to " + data.title)
                 );
             },
             onError: (error) =>

--- a/src/main/webui/src/ProposalEditorView/proposal/Overview.tsx
+++ b/src/main/webui/src/ProposalEditorView/proposal/Overview.tsx
@@ -226,7 +226,7 @@ function ObservationAccordionContent(
  * @return {ReactElement} the html of the overview panel.
  * @constructor
  */
-function OverviewPanel(): ReactElement {
+function OverviewPanel(props: {forceUpdate: () => void}): ReactElement {
 
     const authToken = useToken();
 
@@ -634,17 +634,19 @@ function OverviewPanel(): ReactElement {
 
 
     const handleDeleteProposal = () => {
+
         deleteProposalMutation.mutate({
             pathParams: {proposalCode: Number(selectedProposalCode)}
         },{
             onSuccess: () => {
-                queryClient.invalidateQueries({
-                    queryKey: ['pst', 'api', 'proposals']
-                }).then(() => {
-                    notifySuccess("Deletion successful",
-                        "Proposal: '" + proposalsData?.title! + "' has been removed");
-                });
+                notifySuccess("Deletion successful",
+                    "Proposal: '" + proposalsData?.title! + "' has been removed");
                 navigate("/");
+
+                //workaround: usually you would invalidate queries however this causes this
+                //page to rerender with the now deleted 'selectedProposalCode'. The get proposal
+                //API call will then fail and a 500 code shows up in the console.
+                props.forceUpdate();
             },
             onError: (error) =>
                 notifyError("Deletion failed", getErrorMessage(error))

--- a/src/main/webui/src/commonButtons/contextualHelp.tsx
+++ b/src/main/webui/src/commonButtons/contextualHelp.tsx
@@ -1,49 +1,51 @@
 import {useState} from "react";
-import {Button, Grid, Space} from '@mantine/core';
+import {ActionIcon, Alert, Group, Space, Tooltip} from '@mantine/core';
 import {contextualHelpMessages} from "../../public/contextualHelpMessages.jsx";
-import {IconInfoCircle} from "@tabler/icons-react";
-import {ICON_SIZE} from "../constants.tsx";
+import {IconHelpHexagon, IconHelpHexagonFilled} from "@tabler/icons-react";
+import {ICON_SIZE, OPEN_DELAY} from "../constants.tsx";
 
 export function ContextualHelpButton(props : {messageId : string}) {
 
-  const [showingHelp, setShowingHelp] = useState(false);
+    const [showingHelp, setShowingHelp] = useState(false);
 
-  const userLang = "-eng"; // hard-coded for now, ideally captured from user
+    const userLang = "-eng"; // hard-coded for now, ideally captured from user
 
-  const singleMessage = contextualHelpMessages.filter(aMessage =>
+    const singleMessage =
+      contextualHelpMessages.find(aMessage =>
         aMessage.id === props.messageId + userLang
       );
 
-// need to trap when no message is found...
-
-   const displayHelp = singleMessage.map(aMessage =>
-       <ul key={aMessage.id}>
-           <>{aMessage.message}</>
-       </ul>
-   );
-   const clearHelp = "";
-   const labelClearHelp = "Clear Help";
-   const labelShowHelp = "Show Help";
+    const displayHelp = singleMessage ? singleMessage.message : "";
 
     return (
-
         <>
-        <Space h={"xl"}/>
-        <Grid >
-           <Grid.Col span={10}></Grid.Col>
-           <Button
-               rightSection={<IconInfoCircle size={ICON_SIZE}/>}
-               color="cyan"
-               variant={"subtle"}
-               onClick={() => {setShowingHelp(!showingHelp)}}>
-               {showingHelp ? labelClearHelp : labelShowHelp}
-           </Button>
-        </Grid>
-        <Space h={"xl"} />
-        <div className="display-linebreak" >
-           {showingHelp ? displayHelp : clearHelp}
-        </div>
-        <Space />
+            <Group justify={"flex-end"}>
+                <Tooltip
+                    label={showingHelp? "Close Help" : "Show Help"}
+                    openDelay={OPEN_DELAY}
+                >
+                    <ActionIcon
+                        color="cyan"
+                        variant={"transparent"}
+                        onClick={() => {setShowingHelp(!showingHelp)}}
+                    >
+                        {
+                            showingHelp ? <IconHelpHexagonFilled size={ICON_SIZE}/> :
+                                <IconHelpHexagon size={ICON_SIZE}/>
+                        }
+                    </ActionIcon>
+                </Tooltip>
+            </Group>
+            {
+                showingHelp &&
+                <Group justify={"center"}>
+                    <Alert maw={"75%"}>
+                        {displayHelp}
+                    </Alert>
+                </Group>
+
+            }
+            <Space h={"xl"}/>
         </>
     )
 }


### PR DESCRIPTION
This has been done where possible. The 'downloadProposal' and 'uploadProposal' functions are designed to use promises and as such would need a significant redesign to use mutations. Instead, I have obtained the bearer's auth token at a higher level and passed it to the relevant functions to use in the 'header' part of the 'fetch' calls. 