### PR TITLE
336 reviews change to mutations

### DIFF
--- a/src/main/webui/src/ProposalManagerView/reviews/reviews.form.tsx
+++ b/src/main/webui/src/ProposalManagerView/reviews/reviews.form.tsx
@@ -212,6 +212,7 @@ function ReviewsForm(props: ReviewsProps) : ReactElement {
 
         await queryClient.invalidateQueries()
 
+        //needed to ensure the Update button is disabled after a successful update
         form.resetDirty();
     }
 


### PR DESCRIPTION
Where appropriate fetches have been changed to mutations. Where this is not appropriate i.e., where trying to potentially change multiple review fields concurrently and using async-await semantics, I've left the fetches in, but using the authorisation token obtained from context. 