### PR TITLE
Show multiple submissions of the same source proposal to the same observing cycle

### DIFF
--- a/src/main/webui/Add_@types.patch
+++ b/src/main/webui/Add_@types.patch
@@ -1,0 +1,297 @@
+--- proposalToolSchemas.ts.orig	2025-02-12 15:20:07
++++ proposalToolSchemas.ts	2025-02-12 15:20:09
+@@ -7,6 +7,7 @@
+  * base proposal
+  */
+ export type AbstractProposal = {
++  _id?: number;
+   /**
+    * the proposal title
+    */
+@@ -56,6 +57,8 @@
+  * A block of resources that have been allocated
+  */
+ export type AllocatedBlock = {
++  _id?: number;
++  "@type"?: string; //proposalManagement:AllocatedBlock
+   /**
+    * A resource that will be consumed by allocating an observation from a proposal
+    */
+@@ -74,6 +77,7 @@
+  * an instance of a proposal that is allocated observing time
+  */
+ export type AllocatedProposal = {
++  _id?: number;
+   /**
+    * what is allocated to the proposal
+    */
+@@ -88,6 +92,7 @@
+  * The final grade given by the TAC
+  */
+ export type AllocationGrade = {
++  _id?: number;
+   /**
+    * the name of the grade
+    */
+@@ -179,6 +184,7 @@
+  */
+ export type CalibrationObservation = {
+   xmlId?: string;
++  "@type"?: string;
+   /**
+    * any constraints on the observation
+    */
+@@ -212,6 +218,7 @@
+  * Spatial domain, three-dimensional cartesian coordinate space. The particulars of the axis descriptions depend on the physical constraints of the instance. In Appendix B, we provide the description of a Standard Cartesian Coordinate Space instance which applies to many Astronomical cases, and may be referenced in serializations.
+  */
+ export type CartesianCoordSpace = {
++  "@type"?: string; // coords:CartesianCoordSpace
+   axis?: Axis[];
+ };
+ 
+@@ -238,6 +245,7 @@
+  */
+ export type CelestialTarget = {
+   xmlId?: string;
++  "@type"?: string; // proposal:CelestialTarget
+   /**
+    * A common name for the source
+    */
+@@ -247,7 +255,7 @@
+    */
+   sourceCoordinates?: EquatorialPoint;
+   /**
+-   * We define epoch as a primitive data type with the expected form '{type}{year}' where type = 'J' or 'B' for Julian or Besselian respectively, and year is expressed as a decimal year. e.g.: 'B1950', 'J2000.0'
++   * We define epoch as a primitive data type with the expected form '$type$year' where type = 'J' or 'B' for Julian or Besselian respectively, and year is expressed as a decimal year. e.g.: 'B1950', 'J2000.0'
+    */
+   positionEpoch?: Epoch;
+   /**
+@@ -338,9 +346,7 @@
+ /**
+  * Abstract head of the coordinate system object tree.
+  */
+-export type CoordSys = {
+-  xmlId?: string;
+-};
++export type CoordSys = Record<string, any>;
+ 
+ /**
+  * Abstract base class for the Coordinate data types which represent an absolute location within a coordinate space. Coordinates MUST refer to a coordinate system, providing additional metadata relevant to interpreting the coordinate value, and its representation.
+@@ -475,6 +481,8 @@
+  * A Point on the Unit Sphere
+  */
+ export type EquatorialPoint = {
++  "@type": string; // coords:EquatorialPoint
++  coordSys: CoordSys;
+   /**
+    * A real value with a unit.
+    */
+@@ -521,8 +529,10 @@
+  * Definition of an observing field pointing
+  */
+ export type Field = {
++  "@type"?: string;
+   name?: string;
+   xmlId?: string;
++  _id?: number;
+ };
+ 
+ export type FileUpload = Record<string, any>;
+@@ -751,6 +761,8 @@
+  * An observation - a pointing of the telescope at a part of the sky, occurs in a single non-overlapping time period
+  */
+ export type Observation = {
++  "@type"?: string; //ObsType (see above)
++  _id?: number;
+   /**
+    * any constraints on the observation
+    */
+@@ -799,6 +811,9 @@
+  * An organisation that can perform astronomical observations
+  */
+ export type Observatory = {
++  "@type"?: string;
++  "_id"?: number;
++
+   xmlId?: string;
+   /**
+    * The name of the organization
+@@ -844,6 +859,7 @@
+  * a configuration can be used to observe with.
+  */
+ export type ObservingMode = {
++  _id?: number;
+   /**
+    * human readable name for the mode
+    */
+@@ -882,6 +898,7 @@
+  * a complete proposal
+  */
+ export type ObservingProposal = {
++  _id?: number;
+   xmlId?: string;
+   /**
+    * the proposal title
+@@ -931,6 +948,8 @@
+  * An institution that is a collection of people
+  */
+ export type Organization = {
++  "@type"?: string; // proposal:Organization
++  _id?: number;
+   /**
+    * The name of the organization
+    */
+@@ -1155,6 +1174,8 @@
+  * Defines collection of resources and proposals for a particular observing season
+  */
+ export type ProposalCycle = {
++  _id?: number
++
+   /**
+    * a human readable description of the cycle
+    */
+@@ -1228,6 +1249,7 @@
+  * A review of a proposal
+  */
+ export type ProposalReview = {
++  _id?: number;
+   /**
+    * Description
+    */
+@@ -1309,6 +1331,7 @@
+  * A real value with a unit.
+  */
+ export type RealQuantity = {
++  "@type"?: string; // ivoa:RealQuantity
+   /**
+    * Must conform to definition of unit in VOUnit spec.
+    */
+@@ -1340,6 +1363,8 @@
+  * A resource that will be consumed by allocating an observation from a proposal
+  */
+ export type Resource = {
++  _id?: number;
++
+   /**
+    * The amount of the resource
+    *
+@@ -1370,6 +1395,7 @@
+  * a type of resource
+  */
+ export type ResourceType = {
++  _id?: number;
+   /**
+    * the name of the resource type
+    */
+@@ -1382,6 +1408,7 @@
+  * assigned to review the proposal
+  */
+ export type Reviewer = {
++  _id?: number;
+   /**
+    * person connected with the proposal
+    */
+@@ -1413,6 +1440,8 @@
+   /**
+    * Science oriented definition of a spectral window.
+    */
++  _id?: number;
++
+   spectralWindowSetup?: SpectralWindowSetup;
+   expectedSpectralLine?: ExpectedSpectralLine[];
+ };
+@@ -1457,6 +1486,7 @@
+  * A SpaceFrame is specified by its reference frame (orientation), and a reference position (origin). Currently only standard reference frames are allowed. An equinox MUST be provided for pre-ICRS reference frames. A planetary ephemeris MAY be provided if relevant. If needed, but not provided, it is assumed to be 'DE405'.
+  */
+ export type SpaceFrame = {
++  "@type": string; // coords:SpaceFrame
+   /**
+    * The spatial reference frame. Values MUST be selected from the controlled vocabulary at the given URL.
+    */
+@@ -1479,6 +1509,7 @@
+  * Specialized coordinate system for the Spatial domain. This object SHOULD include an appropriate SpaceFrame. In Appendix B, we define two standard spatial coordinate space instances (Spherical and Cartesian), which may be referenced in serializations. If a CoordSpace is not provided, it is assumed to be represented by a Standard Spherical Coordinate Space.
+  */
+ export type SpaceSys = {
++  "@type": string; // coords:SpaceSys
+   xmlId?: string;
+   /**
+    * Abstract head of coordinate spaces related to physical properties.
+@@ -1562,7 +1593,7 @@
+   /**
+    * person connected with the proposal
+    */
+-  person?: Person | Person;
++  person?: Person;
+   uid?: string;
+   inKeycloakRealm?: boolean;
+ };
+@@ -1582,6 +1613,8 @@
+  * an instance of a proposal that has been submitted
+  */
+ export type SubmittedProposal = {
++  _id?: number;
++
+   xmlId?: string;
+   /**
+    * the proposal title
+@@ -1703,17 +1736,20 @@
+  * A target source
+  */
+ export type Target = {
++  "@type"?: string;
+   /**
+    * A common name for the source
+    */
+   sourceName?: string;
+   xmlId?: string;
++  _id?: number;
+ };
+ 
+ /**
+  * the field points to the associated target
+  */
+ export type TargetField = {
++  "@type"?: string;
+   xmlId?: string;
+   name?: string;
+ };
+@@ -1722,6 +1758,7 @@
+  * an observation of the scientific target
+  */
+ export type TargetObservation = {
++  "@type"?: string;
+   xmlId?: string;
+   /**
+    * any constraints on the observation
+@@ -1750,10 +1787,12 @@
+    */
+   performance?: PerformanceParameters;
+   spectrum?: ScienceSpectralWindow[];
++  _id?: number;
+   xmlId?: string;
+ };
+ 
+ export type Telescope = {
++  "@type"?: string;
+   xmlId?: string;
+   /**
+    * telescope name
+@@ -1773,6 +1812,7 @@
+  * a set of telescopes that are operated together for an observation
+  */
+ export type TelescopeArray = {
++  "@type"?: string;
+   xmlId?: string;
+   /**
+    * the array name
+@@ -1854,6 +1894,10 @@
+  * particular time range
+  */
+ export type TimingWindow = {
++  "@type"?: string; //proposal:TimingWindow
++
++  _id?: number;
++
+   note?: string;
+   isAvoidConstraint?: boolean;
+   /**

--- a/src/main/webui/Add_@types.patch
+++ b/src/main/webui/Add_@types.patch
@@ -1,5 +1,5 @@
 --- proposalToolSchemas.ts.orig	2025-02-12 15:20:07
-+++ proposalToolSchemas.ts	2025-02-12 15:27:33
++++ proposalToolSchemas.ts	2025-02-12 15:45:04
 @@ -7,6 +7,7 @@
   * base proposal
   */
@@ -101,7 +101,7 @@
  };
  
  export type Investigator = {
-+  _id?: string;
++  _id?: number;
    type?: InvestigatorKind;
    /**
     * is the investigator making proposal for their PhD
@@ -154,7 +154,7 @@
     */
    homeInstitute?: Organization;
 -  xmlId?: string;
-+  _id?: string;
++  _id?: number;
  };
  
  /**

--- a/src/main/webui/Add_@types.patch
+++ b/src/main/webui/Add_@types.patch
@@ -1,5 +1,5 @@
 --- proposalToolSchemas.ts.orig	2025-02-12 15:20:07
-+++ proposalToolSchemas.ts	2025-02-12 15:20:09
++++ proposalToolSchemas.ts	2025-02-12 15:27:33
 @@ -7,6 +7,7 @@
   * base proposal
   */
@@ -97,7 +97,15 @@
  };
  
  export type FileUpload = Record<string, any>;
-@@ -751,6 +761,8 @@
+@@ -656,6 +666,7 @@
+ };
+ 
+ export type Investigator = {
++  _id?: string;
+   type?: InvestigatorKind;
+   /**
+    * is the investigator making proposal for their PhD
+@@ -751,6 +762,8 @@
   * An observation - a pointing of the telescope at a part of the sky, occurs in a single non-overlapping time period
   */
  export type Observation = {
@@ -106,7 +114,7 @@
    /**
     * any constraints on the observation
     */
-@@ -799,6 +811,9 @@
+@@ -799,6 +812,9 @@
   * An organisation that can perform astronomical observations
   */
  export type Observatory = {
@@ -116,7 +124,7 @@
    xmlId?: string;
    /**
     * The name of the organization
-@@ -844,6 +859,7 @@
+@@ -844,6 +860,7 @@
   * a configuration can be used to observe with.
   */
  export type ObservingMode = {
@@ -124,7 +132,7 @@
    /**
     * human readable name for the mode
     */
-@@ -882,6 +898,7 @@
+@@ -882,6 +899,7 @@
   * a complete proposal
   */
  export type ObservingProposal = {
@@ -132,7 +140,7 @@
    xmlId?: string;
    /**
     * the proposal title
-@@ -931,6 +948,8 @@
+@@ -931,6 +949,8 @@
   * An institution that is a collection of people
   */
  export type Organization = {
@@ -141,7 +149,16 @@
    /**
     * The name of the organization
     */
-@@ -1155,6 +1174,8 @@
+@@ -993,7 +1013,7 @@
+    * An institution that is a collection of people
+    */
+   homeInstitute?: Organization;
+-  xmlId?: string;
++  _id?: string;
+ };
+ 
+ /**
+@@ -1155,6 +1175,8 @@
   * Defines collection of resources and proposals for a particular observing season
   */
  export type ProposalCycle = {
@@ -150,7 +167,7 @@
    /**
     * a human readable description of the cycle
     */
-@@ -1228,6 +1249,7 @@
+@@ -1228,6 +1250,7 @@
   * A review of a proposal
   */
  export type ProposalReview = {
@@ -158,7 +175,7 @@
    /**
     * Description
     */
-@@ -1309,6 +1331,7 @@
+@@ -1309,6 +1332,7 @@
   * A real value with a unit.
   */
  export type RealQuantity = {
@@ -166,7 +183,7 @@
    /**
     * Must conform to definition of unit in VOUnit spec.
     */
-@@ -1340,6 +1363,8 @@
+@@ -1340,6 +1364,8 @@
   * A resource that will be consumed by allocating an observation from a proposal
   */
  export type Resource = {
@@ -175,7 +192,7 @@
    /**
     * The amount of the resource
     *
-@@ -1370,6 +1395,7 @@
+@@ -1370,6 +1396,7 @@
   * a type of resource
   */
  export type ResourceType = {
@@ -183,7 +200,7 @@
    /**
     * the name of the resource type
     */
-@@ -1382,6 +1408,7 @@
+@@ -1382,6 +1409,7 @@
   * assigned to review the proposal
   */
  export type Reviewer = {
@@ -191,7 +208,7 @@
    /**
     * person connected with the proposal
     */
-@@ -1413,6 +1440,8 @@
+@@ -1413,6 +1441,8 @@
    /**
     * Science oriented definition of a spectral window.
     */
@@ -200,7 +217,7 @@
    spectralWindowSetup?: SpectralWindowSetup;
    expectedSpectralLine?: ExpectedSpectralLine[];
  };
-@@ -1457,6 +1486,7 @@
+@@ -1457,6 +1487,7 @@
   * A SpaceFrame is specified by its reference frame (orientation), and a reference position (origin). Currently only standard reference frames are allowed. An equinox MUST be provided for pre-ICRS reference frames. A planetary ephemeris MAY be provided if relevant. If needed, but not provided, it is assumed to be 'DE405'.
   */
  export type SpaceFrame = {
@@ -208,7 +225,7 @@
    /**
     * The spatial reference frame. Values MUST be selected from the controlled vocabulary at the given URL.
     */
-@@ -1479,6 +1509,7 @@
+@@ -1479,6 +1510,7 @@
   * Specialized coordinate system for the Spatial domain. This object SHOULD include an appropriate SpaceFrame. In Appendix B, we define two standard spatial coordinate space instances (Spherical and Cartesian), which may be referenced in serializations. If a CoordSpace is not provided, it is assumed to be represented by a Standard Spherical Coordinate Space.
   */
  export type SpaceSys = {
@@ -216,7 +233,7 @@
    xmlId?: string;
    /**
     * Abstract head of coordinate spaces related to physical properties.
-@@ -1562,7 +1593,7 @@
+@@ -1562,7 +1594,7 @@
    /**
     * person connected with the proposal
     */
@@ -225,7 +242,7 @@
    uid?: string;
    inKeycloakRealm?: boolean;
  };
-@@ -1582,6 +1613,8 @@
+@@ -1582,6 +1614,8 @@
   * an instance of a proposal that has been submitted
   */
  export type SubmittedProposal = {
@@ -234,7 +251,7 @@
    xmlId?: string;
    /**
     * the proposal title
-@@ -1703,17 +1736,20 @@
+@@ -1703,17 +1737,20 @@
   * A target source
   */
  export type Target = {
@@ -255,7 +272,7 @@
    xmlId?: string;
    name?: string;
  };
-@@ -1722,6 +1758,7 @@
+@@ -1722,6 +1759,7 @@
   * an observation of the scientific target
   */
  export type TargetObservation = {
@@ -263,7 +280,7 @@
    xmlId?: string;
    /**
     * any constraints on the observation
-@@ -1750,10 +1787,12 @@
+@@ -1750,10 +1788,12 @@
     */
    performance?: PerformanceParameters;
    spectrum?: ScienceSpectralWindow[];
@@ -276,7 +293,7 @@
    xmlId?: string;
    /**
     * telescope name
-@@ -1773,6 +1812,7 @@
+@@ -1773,6 +1813,7 @@
   * a set of telescopes that are operated together for an observation
   */
  export type TelescopeArray = {
@@ -284,7 +301,7 @@
    xmlId?: string;
    /**
     * the array name
-@@ -1854,6 +1894,10 @@
+@@ -1854,6 +1895,10 @@
   * particular time range
   */
  export type TimingWindow = {

--- a/src/main/webui/src/generated/proposalToolComponents.ts
+++ b/src/main/webui/src/generated/proposalToolComponents.ts
@@ -528,323 +528,6 @@ export const useObservatoryResourceCreateAndAddArray = (
   });
 };
 
-export type ObservatoryResourceGetObservatoryBackendsPathParams = {
-  /**
-   * @format int64
-   */
-  id: number;
-};
-
-export type ObservatoryResourceGetObservatoryBackendsError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type ObservatoryResourceGetObservatoryBackendsResponse =
-  Schemas.Backend[];
-
-export type ObservatoryResourceGetObservatoryBackendsVariables = {
-  pathParams: ObservatoryResourceGetObservatoryBackendsPathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchObservatoryResourceGetObservatoryBackends = (
-  variables: ObservatoryResourceGetObservatoryBackendsVariables,
-  signal?: AbortSignal,
-) =>
-  proposalToolFetch<
-    ObservatoryResourceGetObservatoryBackendsResponse,
-    ObservatoryResourceGetObservatoryBackendsError,
-    undefined,
-    {},
-    {},
-    ObservatoryResourceGetObservatoryBackendsPathParams
-  >({
-    url: "/pst/api/observatories/{id}/backend",
-    method: "get",
-    ...variables,
-    signal,
-  });
-
-export const useObservatoryResourceGetObservatoryBackends = <
-  TData = ObservatoryResourceGetObservatoryBackendsResponse,
->(
-  variables: ObservatoryResourceGetObservatoryBackendsVariables,
-  options?: Omit<
-    reactQuery.UseQueryOptions<
-      ObservatoryResourceGetObservatoryBackendsResponse,
-      ObservatoryResourceGetObservatoryBackendsError,
-      TData
-    >,
-    "queryKey" | "queryFn" | "initialData"
-  >,
-) => {
-  const { fetcherOptions, queryOptions, queryKeyFn } =
-    useProposalToolContext(options);
-  return reactQuery.useQuery<
-    ObservatoryResourceGetObservatoryBackendsResponse,
-    ObservatoryResourceGetObservatoryBackendsError,
-    TData
-  >({
-    queryKey: queryKeyFn({
-      path: "/pst/api/observatories/{id}/backend",
-      operationId: "observatoryResourceGetObservatoryBackends",
-      variables,
-    }),
-    queryFn: ({ signal }) =>
-      fetchObservatoryResourceGetObservatoryBackends(
-        { ...fetcherOptions, ...variables },
-        signal,
-      ),
-    ...options,
-    ...queryOptions,
-  });
-};
-
-export type ObservatoryResourceAddBackendPathParams = {
-  /**
-   * @format int64
-   */
-  id: number;
-};
-
-export type ObservatoryResourceAddBackendError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type ObservatoryResourceAddBackendVariables = {
-  pathParams: ObservatoryResourceAddBackendPathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchObservatoryResourceAddBackend = (
-  variables: ObservatoryResourceAddBackendVariables,
-  signal?: AbortSignal,
-) =>
-  proposalToolFetch<
-    undefined,
-    ObservatoryResourceAddBackendError,
-    undefined,
-    {},
-    {},
-    ObservatoryResourceAddBackendPathParams
-  >({
-    url: "/pst/api/observatories/{id}/backend",
-    method: "put",
-    ...variables,
-    signal,
-  });
-
-export const useObservatoryResourceAddBackend = (
-  options?: Omit<
-    reactQuery.UseMutationOptions<
-      undefined,
-      ObservatoryResourceAddBackendError,
-      ObservatoryResourceAddBackendVariables
-    >,
-    "mutationFn"
-  >,
-) => {
-  const { fetcherOptions } = useProposalToolContext();
-  return reactQuery.useMutation<
-    undefined,
-    ObservatoryResourceAddBackendError,
-    ObservatoryResourceAddBackendVariables
-  >({
-    mutationFn: (variables: ObservatoryResourceAddBackendVariables) =>
-      fetchObservatoryResourceAddBackend({ ...fetcherOptions, ...variables }),
-    ...options,
-  });
-};
-
-export type ObservatoryResourceCreateAndAddBackendPathParams = {
-  /**
-   * @format int64
-   */
-  id: number;
-};
-
-export type ObservatoryResourceCreateAndAddBackendError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type ObservatoryResourceCreateAndAddBackendVariables = {
-  body?: Schemas.Backend;
-  pathParams: ObservatoryResourceCreateAndAddBackendPathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchObservatoryResourceCreateAndAddBackend = (
-  variables: ObservatoryResourceCreateAndAddBackendVariables,
-  signal?: AbortSignal,
-) =>
-  proposalToolFetch<
-    Schemas.Backend,
-    ObservatoryResourceCreateAndAddBackendError,
-    Schemas.Backend,
-    {},
-    {},
-    ObservatoryResourceCreateAndAddBackendPathParams
-  >({
-    url: "/pst/api/observatories/{id}/backend",
-    method: "post",
-    ...variables,
-    signal,
-  });
-
-export const useObservatoryResourceCreateAndAddBackend = (
-  options?: Omit<
-    reactQuery.UseMutationOptions<
-      Schemas.Backend,
-      ObservatoryResourceCreateAndAddBackendError,
-      ObservatoryResourceCreateAndAddBackendVariables
-    >,
-    "mutationFn"
-  >,
-) => {
-  const { fetcherOptions } = useProposalToolContext();
-  return reactQuery.useMutation<
-    Schemas.Backend,
-    ObservatoryResourceCreateAndAddBackendError,
-    ObservatoryResourceCreateAndAddBackendVariables
-  >({
-    mutationFn: (variables: ObservatoryResourceCreateAndAddBackendVariables) =>
-      fetchObservatoryResourceCreateAndAddBackend({
-        ...fetcherOptions,
-        ...variables,
-      }),
-    ...options,
-  });
-};
-
-export type ObservatoryResourceGetObservatoryBackendPathParams = {
-  /**
-   * @format int64
-   */
-  id: number;
-  /**
-   * @format int64
-   */
-  subId: number;
-};
-
-export type ObservatoryResourceGetObservatoryBackendError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type ObservatoryResourceGetObservatoryBackendVariables = {
-  pathParams: ObservatoryResourceGetObservatoryBackendPathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchObservatoryResourceGetObservatoryBackend = (
-  variables: ObservatoryResourceGetObservatoryBackendVariables,
-  signal?: AbortSignal,
-) =>
-  proposalToolFetch<
-    Schemas.Backend,
-    ObservatoryResourceGetObservatoryBackendError,
-    undefined,
-    {},
-    {},
-    ObservatoryResourceGetObservatoryBackendPathParams
-  >({
-    url: "/pst/api/observatories/{id}/backend/{subId}",
-    method: "get",
-    ...variables,
-    signal,
-  });
-
-export const useObservatoryResourceGetObservatoryBackend = <
-  TData = Schemas.Backend,
->(
-  variables: ObservatoryResourceGetObservatoryBackendVariables,
-  options?: Omit<
-    reactQuery.UseQueryOptions<
-      Schemas.Backend,
-      ObservatoryResourceGetObservatoryBackendError,
-      TData
-    >,
-    "queryKey" | "queryFn" | "initialData"
-  >,
-) => {
-  const { fetcherOptions, queryOptions, queryKeyFn } =
-    useProposalToolContext(options);
-  return reactQuery.useQuery<
-    Schemas.Backend,
-    ObservatoryResourceGetObservatoryBackendError,
-    TData
-  >({
-    queryKey: queryKeyFn({
-      path: "/pst/api/observatories/{id}/backend/{subId}",
-      operationId: "observatoryResourceGetObservatoryBackend",
-      variables,
-    }),
-    queryFn: ({ signal }) =>
-      fetchObservatoryResourceGetObservatoryBackend(
-        { ...fetcherOptions, ...variables },
-        signal,
-      ),
-    ...options,
-    ...queryOptions,
-  });
-};
-
-export type ObservatoryResourceUpdateBackendParallelPathParams = {
-  /**
-   * @format int64
-   */
-  id: number;
-  /**
-   * @format int64
-   */
-  subId: number;
-};
-
-export type ObservatoryResourceUpdateBackendParallelError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type ObservatoryResourceUpdateBackendParallelVariables = {
-  body?: boolean;
-  pathParams: ObservatoryResourceUpdateBackendParallelPathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchObservatoryResourceUpdateBackendParallel = (
-  variables: ObservatoryResourceUpdateBackendParallelVariables,
-  signal?: AbortSignal,
-) =>
-  proposalToolFetch<
-    undefined,
-    ObservatoryResourceUpdateBackendParallelError,
-    boolean,
-    {},
-    {},
-    ObservatoryResourceUpdateBackendParallelPathParams
-  >({
-    url: "/pst/api/observatories/{id}/backend/{subId}/parallel",
-    method: "put",
-    ...variables,
-    signal,
-  });
-
-export const useObservatoryResourceUpdateBackendParallel = (
-  options?: Omit<
-    reactQuery.UseMutationOptions<
-      undefined,
-      ObservatoryResourceUpdateBackendParallelError,
-      ObservatoryResourceUpdateBackendParallelVariables
-    >,
-    "mutationFn"
-  >,
-) => {
-  const { fetcherOptions } = useProposalToolContext();
-  return reactQuery.useMutation<
-    undefined,
-    ObservatoryResourceUpdateBackendParallelError,
-    ObservatoryResourceUpdateBackendParallelVariables
-  >({
-    mutationFn: (
-      variables: ObservatoryResourceUpdateBackendParallelVariables,
-    ) =>
-      fetchObservatoryResourceUpdateBackendParallel({
-        ...fetcherOptions,
-        ...variables,
-      }),
-    ...options,
-  });
-};
-
 export type ObservatoryResourceUpdateObservatoryIvoIdPathParams = {
   /**
    * @format int64
@@ -1022,7 +705,193 @@ export const useObservatoryResourceUpdateObservatoryWikiId = (
   });
 };
 
-export type ObservatoryResourceReplaceBackendNamePathParams = {
+export type BackendResourceGetObservatoryBackendsPathParams = {
+  /**
+   * @format int64
+   */
+  observatoryId: number;
+};
+
+export type BackendResourceGetObservatoryBackendsQueryParams = {
+  name?: string;
+};
+
+export type BackendResourceGetObservatoryBackendsError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type BackendResourceGetObservatoryBackendsResponse =
+  Schemas.ObjectIdentifier[];
+
+export type BackendResourceGetObservatoryBackendsVariables = {
+  pathParams: BackendResourceGetObservatoryBackendsPathParams;
+  queryParams?: BackendResourceGetObservatoryBackendsQueryParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchBackendResourceGetObservatoryBackends = (
+  variables: BackendResourceGetObservatoryBackendsVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    BackendResourceGetObservatoryBackendsResponse,
+    BackendResourceGetObservatoryBackendsError,
+    undefined,
+    {},
+    BackendResourceGetObservatoryBackendsQueryParams,
+    BackendResourceGetObservatoryBackendsPathParams
+  >({
+    url: "/pst/api/observatories/{observatoryId}/backends",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export const useBackendResourceGetObservatoryBackends = <
+  TData = BackendResourceGetObservatoryBackendsResponse,
+>(
+  variables: BackendResourceGetObservatoryBackendsVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      BackendResourceGetObservatoryBackendsResponse,
+      BackendResourceGetObservatoryBackendsError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { fetcherOptions, queryOptions, queryKeyFn } =
+    useProposalToolContext(options);
+  return reactQuery.useQuery<
+    BackendResourceGetObservatoryBackendsResponse,
+    BackendResourceGetObservatoryBackendsError,
+    TData
+  >({
+    queryKey: queryKeyFn({
+      path: "/pst/api/observatories/{observatoryId}/backends",
+      operationId: "backendResourceGetObservatoryBackends",
+      variables,
+    }),
+    queryFn: ({ signal }) =>
+      fetchBackendResourceGetObservatoryBackends(
+        { ...fetcherOptions, ...variables },
+        signal,
+      ),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export type BackendResourceAddBackendPathParams = {
+  /**
+   * @format int64
+   */
+  observatoryId: number;
+};
+
+export type BackendResourceAddBackendError = Fetcher.ErrorWrapper<undefined>;
+
+export type BackendResourceAddBackendVariables = {
+  pathParams: BackendResourceAddBackendPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchBackendResourceAddBackend = (
+  variables: BackendResourceAddBackendVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    BackendResourceAddBackendError,
+    undefined,
+    {},
+    {},
+    BackendResourceAddBackendPathParams
+  >({
+    url: "/pst/api/observatories/{observatoryId}/backends",
+    method: "put",
+    ...variables,
+    signal,
+  });
+
+export const useBackendResourceAddBackend = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      BackendResourceAddBackendError,
+      BackendResourceAddBackendVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    undefined,
+    BackendResourceAddBackendError,
+    BackendResourceAddBackendVariables
+  >({
+    mutationFn: (variables: BackendResourceAddBackendVariables) =>
+      fetchBackendResourceAddBackend({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
+export type BackendResourceCreateAndAddBackendPathParams = {
+  /**
+   * @format int64
+   */
+  observatoryId: number;
+};
+
+export type BackendResourceCreateAndAddBackendError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type BackendResourceCreateAndAddBackendVariables = {
+  body?: Schemas.Backend;
+  pathParams: BackendResourceCreateAndAddBackendPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchBackendResourceCreateAndAddBackend = (
+  variables: BackendResourceCreateAndAddBackendVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    Schemas.Backend,
+    BackendResourceCreateAndAddBackendError,
+    Schemas.Backend,
+    {},
+    {},
+    BackendResourceCreateAndAddBackendPathParams
+  >({
+    url: "/pst/api/observatories/{observatoryId}/backends",
+    method: "post",
+    ...variables,
+    signal,
+  });
+
+export const useBackendResourceCreateAndAddBackend = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      Schemas.Backend,
+      BackendResourceCreateAndAddBackendError,
+      BackendResourceCreateAndAddBackendVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    Schemas.Backend,
+    BackendResourceCreateAndAddBackendError,
+    BackendResourceCreateAndAddBackendVariables
+  >({
+    mutationFn: (variables: BackendResourceCreateAndAddBackendVariables) =>
+      fetchBackendResourceCreateAndAddBackend({
+        ...fetcherOptions,
+        ...variables,
+      }),
+    ...options,
+  });
+};
+
+export type BackendResourceGetObservatoryBackendPathParams = {
   /**
    * @format int64
    */
@@ -1033,37 +902,108 @@ export type ObservatoryResourceReplaceBackendNamePathParams = {
   observatoryId: number;
 };
 
-export type ObservatoryResourceReplaceBackendNameError =
+export type BackendResourceGetObservatoryBackendError =
   Fetcher.ErrorWrapper<undefined>;
 
-export type ObservatoryResourceReplaceBackendNameVariables = {
-  pathParams: ObservatoryResourceReplaceBackendNamePathParams;
+export type BackendResourceGetObservatoryBackendVariables = {
+  pathParams: BackendResourceGetObservatoryBackendPathParams;
 } & ProposalToolContext["fetcherOptions"];
 
-export const fetchObservatoryResourceReplaceBackendName = (
-  variables: ObservatoryResourceReplaceBackendNameVariables,
+export const fetchBackendResourceGetObservatoryBackend = (
+  variables: BackendResourceGetObservatoryBackendVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    Schemas.Backend,
+    BackendResourceGetObservatoryBackendError,
+    undefined,
+    {},
+    {},
+    BackendResourceGetObservatoryBackendPathParams
+  >({
+    url: "/pst/api/observatories/{observatoryId}/backends/{backendId}",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export const useBackendResourceGetObservatoryBackend = <
+  TData = Schemas.Backend,
+>(
+  variables: BackendResourceGetObservatoryBackendVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      Schemas.Backend,
+      BackendResourceGetObservatoryBackendError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { fetcherOptions, queryOptions, queryKeyFn } =
+    useProposalToolContext(options);
+  return reactQuery.useQuery<
+    Schemas.Backend,
+    BackendResourceGetObservatoryBackendError,
+    TData
+  >({
+    queryKey: queryKeyFn({
+      path: "/pst/api/observatories/{observatoryId}/backends/{backendId}",
+      operationId: "backendResourceGetObservatoryBackend",
+      variables,
+    }),
+    queryFn: ({ signal }) =>
+      fetchBackendResourceGetObservatoryBackend(
+        { ...fetcherOptions, ...variables },
+        signal,
+      ),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export type BackendResourceReplaceBackendNamePathParams = {
+  /**
+   * @format int64
+   */
+  backendId: number;
+  /**
+   * @format int64
+   */
+  observatoryId: number;
+};
+
+export type BackendResourceReplaceBackendNameError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type BackendResourceReplaceBackendNameVariables = {
+  pathParams: BackendResourceReplaceBackendNamePathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchBackendResourceReplaceBackendName = (
+  variables: BackendResourceReplaceBackendNameVariables,
   signal?: AbortSignal,
 ) =>
   proposalToolFetch<
     undefined,
-    ObservatoryResourceReplaceBackendNameError,
+    BackendResourceReplaceBackendNameError,
     undefined,
     {},
     {},
-    ObservatoryResourceReplaceBackendNamePathParams
+    BackendResourceReplaceBackendNamePathParams
   >({
-    url: "/pst/api/observatories/{observatoryId}/backend/{backendId}/name",
+    url: "/pst/api/observatories/{observatoryId}/backends/{backendId}/name",
     method: "put",
     ...variables,
     signal,
   });
 
-export const useObservatoryResourceReplaceBackendName = (
+export const useBackendResourceReplaceBackendName = (
   options?: Omit<
     reactQuery.UseMutationOptions<
       undefined,
-      ObservatoryResourceReplaceBackendNameError,
-      ObservatoryResourceReplaceBackendNameVariables
+      BackendResourceReplaceBackendNameError,
+      BackendResourceReplaceBackendNameVariables
     >,
     "mutationFn"
   >,
@@ -1071,11 +1011,73 @@ export const useObservatoryResourceReplaceBackendName = (
   const { fetcherOptions } = useProposalToolContext();
   return reactQuery.useMutation<
     undefined,
-    ObservatoryResourceReplaceBackendNameError,
-    ObservatoryResourceReplaceBackendNameVariables
+    BackendResourceReplaceBackendNameError,
+    BackendResourceReplaceBackendNameVariables
   >({
-    mutationFn: (variables: ObservatoryResourceReplaceBackendNameVariables) =>
-      fetchObservatoryResourceReplaceBackendName({
+    mutationFn: (variables: BackendResourceReplaceBackendNameVariables) =>
+      fetchBackendResourceReplaceBackendName({
+        ...fetcherOptions,
+        ...variables,
+      }),
+    ...options,
+  });
+};
+
+export type BackendResourceUpdateBackendParallelPathParams = {
+  /**
+   * @format int64
+   */
+  backendId: number;
+  /**
+   * @format int64
+   */
+  observatoryId: number;
+};
+
+export type BackendResourceUpdateBackendParallelError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type BackendResourceUpdateBackendParallelVariables = {
+  body?: boolean;
+  pathParams: BackendResourceUpdateBackendParallelPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchBackendResourceUpdateBackendParallel = (
+  variables: BackendResourceUpdateBackendParallelVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    BackendResourceUpdateBackendParallelError,
+    boolean,
+    {},
+    {},
+    BackendResourceUpdateBackendParallelPathParams
+  >({
+    url: "/pst/api/observatories/{observatoryId}/backends/{backendId}/parallel",
+    method: "put",
+    ...variables,
+    signal,
+  });
+
+export const useBackendResourceUpdateBackendParallel = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      BackendResourceUpdateBackendParallelError,
+      BackendResourceUpdateBackendParallelVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    undefined,
+    BackendResourceUpdateBackendParallelError,
+    BackendResourceUpdateBackendParallelVariables
+  >({
+    mutationFn: (variables: BackendResourceUpdateBackendParallelVariables) =>
+      fetchBackendResourceUpdateBackendParallel({
         ...fetcherOptions,
         ...variables,
       }),
@@ -5975,6 +5977,10 @@ export type SubmittedProposalResourceGetSubmittedProposalsPathParams = {
 
 export type SubmittedProposalResourceGetSubmittedProposalsQueryParams = {
   investigatorName?: string;
+  /**
+   * @format int64
+   */
+  sourceProposalId?: number;
   title?: string;
 };
 
@@ -12590,14 +12596,14 @@ export type QueryOperation =
       variables: ObservatoryResourceGetObservatoryVariables;
     }
   | {
-      path: "/pst/api/observatories/{id}/backend";
-      operationId: "observatoryResourceGetObservatoryBackends";
-      variables: ObservatoryResourceGetObservatoryBackendsVariables;
+      path: "/pst/api/observatories/{observatoryId}/backends";
+      operationId: "backendResourceGetObservatoryBackends";
+      variables: BackendResourceGetObservatoryBackendsVariables;
     }
   | {
-      path: "/pst/api/observatories/{id}/backend/{subId}";
-      operationId: "observatoryResourceGetObservatoryBackend";
-      variables: ObservatoryResourceGetObservatoryBackendVariables;
+      path: "/pst/api/observatories/{observatoryId}/backends/{backendId}";
+      operationId: "backendResourceGetObservatoryBackend";
+      variables: BackendResourceGetObservatoryBackendVariables;
     }
   | {
       path: "/pst/api/observatories/{observatoryId}/instruments";

--- a/src/main/webui/src/generated/proposalToolSchemas.ts
+++ b/src/main/webui/src/generated/proposalToolSchemas.ts
@@ -666,7 +666,7 @@ export type IntegerQuantity = {
 };
 
 export type Investigator = {
-  _id?: string;
+  _id?: number;
   type?: InvestigatorKind;
   /**
    * is the investigator making proposal for their PhD
@@ -1013,7 +1013,7 @@ export type Person = {
    * An institution that is a collection of people
    */
   homeInstitute?: Organization;
-  _id?: string;
+  _id?: number;
 };
 
 /**

--- a/src/main/webui/src/generated/proposalToolSchemas.ts
+++ b/src/main/webui/src/generated/proposalToolSchemas.ts
@@ -7,6 +7,7 @@
  * base proposal
  */
 export type AbstractProposal = {
+  _id?: number;
   /**
    * the proposal title
    */
@@ -56,6 +57,8 @@ export type AbstractProposal = {
  * A block of resources that have been allocated
  */
 export type AllocatedBlock = {
+  _id?: number;
+  "@type"?: string; //proposalManagement:AllocatedBlock
   /**
    * A resource that will be consumed by allocating an observation from a proposal
    */
@@ -74,6 +77,7 @@ export type AllocatedBlock = {
  * an instance of a proposal that is allocated observing time
  */
 export type AllocatedProposal = {
+  _id?: number;
   /**
    * what is allocated to the proposal
    */
@@ -88,6 +92,7 @@ export type AllocatedProposal = {
  * The final grade given by the TAC
  */
 export type AllocationGrade = {
+  _id?: number;
   /**
    * the name of the grade
    */
@@ -179,6 +184,7 @@ export type BinnedCoordinate = {
  */
 export type CalibrationObservation = {
   xmlId?: string;
+  "@type"?: string;
   /**
    * any constraints on the observation
    */
@@ -212,6 +218,7 @@ export type CalibrationTargetIntendedUse =
  * Spatial domain, three-dimensional cartesian coordinate space. The particulars of the axis descriptions depend on the physical constraints of the instance. In Appendix B, we provide the description of a Standard Cartesian Coordinate Space instance which applies to many Astronomical cases, and may be referenced in serializations.
  */
 export type CartesianCoordSpace = {
+  "@type"?: string; // coords:CartesianCoordSpace
   axis?: Axis[];
 };
 
@@ -238,6 +245,7 @@ export type CartesianPoint = {
  */
 export type CelestialTarget = {
   xmlId?: string;
+  "@type"?: string; // proposal:CelestialTarget
   /**
    * A common name for the source
    */
@@ -247,7 +255,7 @@ export type CelestialTarget = {
    */
   sourceCoordinates?: EquatorialPoint;
   /**
-   * We define epoch as a primitive data type with the expected form '{type}{year}' where type = 'J' or 'B' for Julian or Besselian respectively, and year is expressed as a decimal year. e.g.: 'B1950', 'J2000.0'
+   * We define epoch as a primitive data type with the expected form '$type$year' where type = 'J' or 'B' for Julian or Besselian respectively, and year is expressed as a decimal year. e.g.: 'B1950', 'J2000.0'
    */
   positionEpoch?: Epoch;
   /**
@@ -338,9 +346,7 @@ export type CoordSpace = {
 /**
  * Abstract head of the coordinate system object tree.
  */
-export type CoordSys = {
-  xmlId?: string;
-};
+export type CoordSys = Record<string, any>;
 
 /**
  * Abstract base class for the Coordinate data types which represent an absolute location within a coordinate space. Coordinates MUST refer to a coordinate system, providing additional metadata relevant to interpreting the coordinate value, and its representation.
@@ -475,6 +481,8 @@ export type Epoch = {
  * A Point on the Unit Sphere
  */
 export type EquatorialPoint = {
+  "@type": string; // coords:EquatorialPoint
+  coordSys: CoordSys;
   /**
    * A real value with a unit.
    */
@@ -521,8 +529,10 @@ export type FederatedIdentityRepresentation = {
  * Definition of an observing field pointing
  */
 export type Field = {
+  "@type"?: string;
   name?: string;
   xmlId?: string;
+  _id?: number;
 };
 
 export type FileUpload = Record<string, any>;
@@ -751,6 +761,8 @@ export type ObsType = "TargetObservation" | "CalibrationObservation";
  * An observation - a pointing of the telescope at a part of the sky, occurs in a single non-overlapping time period
  */
 export type Observation = {
+  "@type"?: string; //ObsType (see above)
+  _id?: number;
   /**
    * any constraints on the observation
    */
@@ -799,6 +811,9 @@ export type ObservationConfiguration = {
  * An organisation that can perform astronomical observations
  */
 export type Observatory = {
+  "@type"?: string;
+  "_id"?: number;
+
   xmlId?: string;
   /**
    * The name of the organization
@@ -844,6 +859,7 @@ export type ObservingConstraint = Record<string, any>;
  * a configuration can be used to observe with.
  */
 export type ObservingMode = {
+  _id?: number;
   /**
    * human readable name for the mode
    */
@@ -882,6 +898,7 @@ export type ObservingPlatform = {
  * a complete proposal
  */
 export type ObservingProposal = {
+  _id?: number;
   xmlId?: string;
   /**
    * the proposal title
@@ -931,6 +948,8 @@ export type ObservingProposal = {
  * An institution that is a collection of people
  */
 export type Organization = {
+  "@type"?: string; // proposal:Organization
+  _id?: number;
   /**
    * The name of the organization
    */
@@ -1155,6 +1174,8 @@ export type Polygon = {
  * Defines collection of resources and proposals for a particular observing season
  */
 export type ProposalCycle = {
+  _id?: number
+
   /**
    * a human readable description of the cycle
    */
@@ -1228,6 +1249,7 @@ export type ProposalKind = "Standard" | "ToO" | "Survey";
  * A review of a proposal
  */
 export type ProposalReview = {
+  _id?: number;
   /**
    * Description
    */
@@ -1309,6 +1331,7 @@ export type RealCartesianPoint = {
  * A real value with a unit.
  */
 export type RealQuantity = {
+  "@type"?: string; // ivoa:RealQuantity
   /**
    * Must conform to definition of unit in VOUnit spec.
    */
@@ -1340,6 +1363,8 @@ export type RelatedProposal = {
  * A resource that will be consumed by allocating an observation from a proposal
  */
 export type Resource = {
+  _id?: number;
+
   /**
    * The amount of the resource
    *
@@ -1370,6 +1395,7 @@ export type ResourceBlock = {
  * a type of resource
  */
 export type ResourceType = {
+  _id?: number;
   /**
    * the name of the resource type
    */
@@ -1382,6 +1408,7 @@ export type ResourceType = {
  * assigned to review the proposal
  */
 export type Reviewer = {
+  _id?: number;
   /**
    * person connected with the proposal
    */
@@ -1413,6 +1440,8 @@ export type ScienceSpectralWindow = {
   /**
    * Science oriented definition of a spectral window.
    */
+  _id?: number;
+
   spectralWindowSetup?: SpectralWindowSetup;
   expectedSpectralLine?: ExpectedSpectralLine[];
 };
@@ -1457,6 +1486,7 @@ export type SolarSystemTarget = {
  * A SpaceFrame is specified by its reference frame (orientation), and a reference position (origin). Currently only standard reference frames are allowed. An equinox MUST be provided for pre-ICRS reference frames. A planetary ephemeris MAY be provided if relevant. If needed, but not provided, it is assumed to be 'DE405'.
  */
 export type SpaceFrame = {
+  "@type": string; // coords:SpaceFrame
   /**
    * The spatial reference frame. Values MUST be selected from the controlled vocabulary at the given URL.
    */
@@ -1479,6 +1509,7 @@ export type SpaceFrame = {
  * Specialized coordinate system for the Spatial domain. This object SHOULD include an appropriate SpaceFrame. In Appendix B, we define two standard spatial coordinate space instances (Spherical and Cartesian), which may be referenced in serializations. If a CoordSpace is not provided, it is assumed to be represented by a Standard Spherical Coordinate Space.
  */
 export type SpaceSys = {
+  "@type": string; // coords:SpaceSys
   xmlId?: string;
   /**
    * Abstract head of coordinate spaces related to physical properties.
@@ -1562,7 +1593,7 @@ export type SubjectMap = {
   /**
    * person connected with the proposal
    */
-  person?: Person | Person;
+  person?: Person;
   uid?: string;
   inKeycloakRealm?: boolean;
 };
@@ -1582,6 +1613,8 @@ export type SubmissionConfiguration = {
  * an instance of a proposal that has been submitted
  */
 export type SubmittedProposal = {
+  _id?: number;
+
   xmlId?: string;
   /**
    * the proposal title
@@ -1703,17 +1736,20 @@ export type TacRole = "TechnicalReviewer" | "ScienceReviewer" | "Chair";
  * A target source
  */
 export type Target = {
+  "@type"?: string;
   /**
    * A common name for the source
    */
   sourceName?: string;
   xmlId?: string;
+  _id?: number;
 };
 
 /**
  * the field points to the associated target
  */
 export type TargetField = {
+  "@type"?: string;
   xmlId?: string;
   name?: string;
 };
@@ -1722,6 +1758,7 @@ export type TargetField = {
  * an observation of the scientific target
  */
 export type TargetObservation = {
+  "@type"?: string;
   xmlId?: string;
   /**
    * any constraints on the observation
@@ -1750,10 +1787,12 @@ export type TechnicalGoal = {
    */
   performance?: PerformanceParameters;
   spectrum?: ScienceSpectralWindow[];
+  _id?: number;
   xmlId?: string;
 };
 
 export type Telescope = {
+  "@type"?: string;
   xmlId?: string;
   /**
    * telescope name
@@ -1773,6 +1812,7 @@ export type Telescope = {
  * a set of telescopes that are operated together for an observation
  */
 export type TelescopeArray = {
+  "@type"?: string;
   xmlId?: string;
   /**
    * the array name
@@ -1854,6 +1894,10 @@ export type TimingConstraint = {
  * particular time range
  */
 export type TimingWindow = {
+  "@type"?: string; //proposal:TimingWindow
+
+  _id?: number;
+
   note?: string;
   isAvoidConstraint?: boolean;
   /**

--- a/src/main/webui/src/generated/proposalToolSchemas.ts
+++ b/src/main/webui/src/generated/proposalToolSchemas.ts
@@ -7,7 +7,6 @@
  * base proposal
  */
 export type AbstractProposal = {
-  _id?: number;
   /**
    * the proposal title
    */
@@ -57,8 +56,6 @@ export type AbstractProposal = {
  * A block of resources that have been allocated
  */
 export type AllocatedBlock = {
-  _id?: number;
-  "@type"?: string; //proposalManagement:AllocatedBlock
   /**
    * A resource that will be consumed by allocating an observation from a proposal
    */
@@ -77,7 +74,6 @@ export type AllocatedBlock = {
  * an instance of a proposal that is allocated observing time
  */
 export type AllocatedProposal = {
-  _id?: number;
   /**
    * what is allocated to the proposal
    */
@@ -92,7 +88,6 @@ export type AllocatedProposal = {
  * The final grade given by the TAC
  */
 export type AllocationGrade = {
-  _id?: number;
   /**
    * the name of the grade
    */
@@ -184,7 +179,6 @@ export type BinnedCoordinate = {
  */
 export type CalibrationObservation = {
   xmlId?: string;
-  "@type"?: string;
   /**
    * any constraints on the observation
    */
@@ -218,7 +212,6 @@ export type CalibrationTargetIntendedUse =
  * Spatial domain, three-dimensional cartesian coordinate space. The particulars of the axis descriptions depend on the physical constraints of the instance. In Appendix B, we provide the description of a Standard Cartesian Coordinate Space instance which applies to many Astronomical cases, and may be referenced in serializations.
  */
 export type CartesianCoordSpace = {
-  "@type"?: string; // coords:CartesianCoordSpace
   axis?: Axis[];
 };
 
@@ -245,7 +238,6 @@ export type CartesianPoint = {
  */
 export type CelestialTarget = {
   xmlId?: string;
-  "@type"?: string; // proposal:CelestialTarget
   /**
    * A common name for the source
    */
@@ -255,7 +247,7 @@ export type CelestialTarget = {
    */
   sourceCoordinates?: EquatorialPoint;
   /**
-   * We define epoch as a primitive data type with the expected form '$type$year' where type = 'J' or 'B' for Julian or Besselian respectively, and year is expressed as a decimal year. e.g.: 'B1950', 'J2000.0'
+   * We define epoch as a primitive data type with the expected form '{type}{year}' where type = 'J' or 'B' for Julian or Besselian respectively, and year is expressed as a decimal year. e.g.: 'B1950', 'J2000.0'
    */
   positionEpoch?: Epoch;
   /**
@@ -346,7 +338,9 @@ export type CoordSpace = {
 /**
  * Abstract head of the coordinate system object tree.
  */
-export type CoordSys = Record<string, any>;
+export type CoordSys = {
+  xmlId?: string;
+};
 
 /**
  * Abstract base class for the Coordinate data types which represent an absolute location within a coordinate space. Coordinates MUST refer to a coordinate system, providing additional metadata relevant to interpreting the coordinate value, and its representation.
@@ -481,8 +475,6 @@ export type Epoch = {
  * A Point on the Unit Sphere
  */
 export type EquatorialPoint = {
-  "@type": string; // coords:EquatorialPoint
-  coordSys: CoordSys;
   /**
    * A real value with a unit.
    */
@@ -529,10 +521,8 @@ export type FederatedIdentityRepresentation = {
  * Definition of an observing field pointing
  */
 export type Field = {
-  "@type"?: string;
   name?: string;
   xmlId?: string;
-  _id?: number;
 };
 
 export type FileUpload = Record<string, any>;
@@ -666,7 +656,6 @@ export type IntegerQuantity = {
 };
 
 export type Investigator = {
-  _id?: number;
   type?: InvestigatorKind;
   /**
    * is the investigator making proposal for their PhD
@@ -762,8 +751,6 @@ export type ObsType = "TargetObservation" | "CalibrationObservation";
  * An observation - a pointing of the telescope at a part of the sky, occurs in a single non-overlapping time period
  */
 export type Observation = {
-  "@type"?: string; //ObsType (see above)
-  _id?: number;
   /**
    * any constraints on the observation
    */
@@ -812,9 +799,6 @@ export type ObservationConfiguration = {
  * An organisation that can perform astronomical observations
  */
 export type Observatory = {
-  "@type"?: string;
-  "_id"?: number;
-
   xmlId?: string;
   /**
    * The name of the organization
@@ -860,7 +844,6 @@ export type ObservingConstraint = Record<string, any>;
  * a configuration can be used to observe with.
  */
 export type ObservingMode = {
-  _id?: number;
   /**
    * human readable name for the mode
    */
@@ -899,7 +882,6 @@ export type ObservingPlatform = {
  * a complete proposal
  */
 export type ObservingProposal = {
-  _id?: number;
   xmlId?: string;
   /**
    * the proposal title
@@ -949,8 +931,6 @@ export type ObservingProposal = {
  * An institution that is a collection of people
  */
 export type Organization = {
-  "@type"?: string; // proposal:Organization
-  _id?: number;
   /**
    * The name of the organization
    */
@@ -1013,7 +993,7 @@ export type Person = {
    * An institution that is a collection of people
    */
   homeInstitute?: Organization;
-  _id?: string;
+  xmlId?: string;
 };
 
 /**
@@ -1175,8 +1155,6 @@ export type Polygon = {
  * Defines collection of resources and proposals for a particular observing season
  */
 export type ProposalCycle = {
-  _id?: number
-
   /**
    * a human readable description of the cycle
    */
@@ -1250,7 +1228,6 @@ export type ProposalKind = "Standard" | "ToO" | "Survey";
  * A review of a proposal
  */
 export type ProposalReview = {
-  _id?: number;
   /**
    * Description
    */
@@ -1332,7 +1309,6 @@ export type RealCartesianPoint = {
  * A real value with a unit.
  */
 export type RealQuantity = {
-  "@type"?: string; // ivoa:RealQuantity
   /**
    * Must conform to definition of unit in VOUnit spec.
    */
@@ -1364,8 +1340,6 @@ export type RelatedProposal = {
  * A resource that will be consumed by allocating an observation from a proposal
  */
 export type Resource = {
-  _id?: number;
-
   /**
    * The amount of the resource
    *
@@ -1396,7 +1370,6 @@ export type ResourceBlock = {
  * a type of resource
  */
 export type ResourceType = {
-  _id?: number;
   /**
    * the name of the resource type
    */
@@ -1409,7 +1382,6 @@ export type ResourceType = {
  * assigned to review the proposal
  */
 export type Reviewer = {
-  _id?: number;
   /**
    * person connected with the proposal
    */
@@ -1441,8 +1413,6 @@ export type ScienceSpectralWindow = {
   /**
    * Science oriented definition of a spectral window.
    */
-  _id?: number;
-
   spectralWindowSetup?: SpectralWindowSetup;
   expectedSpectralLine?: ExpectedSpectralLine[];
 };
@@ -1487,7 +1457,6 @@ export type SolarSystemTarget = {
  * A SpaceFrame is specified by its reference frame (orientation), and a reference position (origin). Currently only standard reference frames are allowed. An equinox MUST be provided for pre-ICRS reference frames. A planetary ephemeris MAY be provided if relevant. If needed, but not provided, it is assumed to be 'DE405'.
  */
 export type SpaceFrame = {
-  "@type": string; // coords:SpaceFrame
   /**
    * The spatial reference frame. Values MUST be selected from the controlled vocabulary at the given URL.
    */
@@ -1510,7 +1479,6 @@ export type SpaceFrame = {
  * Specialized coordinate system for the Spatial domain. This object SHOULD include an appropriate SpaceFrame. In Appendix B, we define two standard spatial coordinate space instances (Spherical and Cartesian), which may be referenced in serializations. If a CoordSpace is not provided, it is assumed to be represented by a Standard Spherical Coordinate Space.
  */
 export type SpaceSys = {
-  "@type": string; // coords:SpaceSys
   xmlId?: string;
   /**
    * Abstract head of coordinate spaces related to physical properties.
@@ -1594,7 +1562,7 @@ export type SubjectMap = {
   /**
    * person connected with the proposal
    */
-  person?: Person;
+  person?: Person | Person;
   uid?: string;
   inKeycloakRealm?: boolean;
 };
@@ -1614,8 +1582,6 @@ export type SubmissionConfiguration = {
  * an instance of a proposal that has been submitted
  */
 export type SubmittedProposal = {
-  _id?: number;
-
   xmlId?: string;
   /**
    * the proposal title
@@ -1737,20 +1703,17 @@ export type TacRole = "TechnicalReviewer" | "ScienceReviewer" | "Chair";
  * A target source
  */
 export type Target = {
-  "@type"?: string;
   /**
    * A common name for the source
    */
   sourceName?: string;
   xmlId?: string;
-  _id?: number;
 };
 
 /**
  * the field points to the associated target
  */
 export type TargetField = {
-  "@type"?: string;
   xmlId?: string;
   name?: string;
 };
@@ -1759,7 +1722,6 @@ export type TargetField = {
  * an observation of the scientific target
  */
 export type TargetObservation = {
-  "@type"?: string;
   xmlId?: string;
   /**
    * any constraints on the observation
@@ -1788,12 +1750,10 @@ export type TechnicalGoal = {
    */
   performance?: PerformanceParameters;
   spectrum?: ScienceSpectralWindow[];
-  _id?: number;
   xmlId?: string;
 };
 
 export type Telescope = {
-  "@type"?: string;
   xmlId?: string;
   /**
    * telescope name
@@ -1813,7 +1773,6 @@ export type Telescope = {
  * a set of telescopes that are operated together for an observation
  */
 export type TelescopeArray = {
-  "@type"?: string;
   xmlId?: string;
   /**
    * the array name
@@ -1895,10 +1854,6 @@ export type TimingConstraint = {
  * particular time range
  */
 export type TimingWindow = {
-  "@type"?: string; //proposal:TimingWindow
-
-  _id?: number;
-
   note?: string;
   isAvoidConstraint?: boolean;
   /**

--- a/src/main/webui/src/generated/proposalToolSchemas.ts
+++ b/src/main/webui/src/generated/proposalToolSchemas.ts
@@ -666,6 +666,7 @@ export type IntegerQuantity = {
 };
 
 export type Investigator = {
+  _id?: string;
   type?: InvestigatorKind;
   /**
    * is the investigator making proposal for their PhD
@@ -1012,7 +1013,7 @@ export type Person = {
    * An institution that is a collection of people
    */
   homeInstitute?: Organization;
-  xmlId?: string;
+  _id?: string;
 };
 
 /**


### PR DESCRIPTION
Change submitted proposal list to match by source proposalID, display multiple submissions to the same cycle where they exist.  Allow any of these to be withdrawn individually.

Please note that when starting from scratch the example proposal will no longer show as submitted to either cycle.  This is because the model example does not populate the related proposal composition after submitting.  Yes, this caught me out and had me confused for some time!  Any proposal submitted using the GUI (and thus the API) will appear in the list.