### PR TITLE
369 reformat add target to use page instead of modal

### DIFF
--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -78,6 +78,7 @@ import EditorLandingPage from "./ProposalEditorView/landingPage/editorLandingPag
 import TitleSummaryKind from "./ProposalEditorView/proposal/TitleSummaryKind.tsx";
 import {notifyError} from "./commonPanel/notifications.tsx";
 import JSZip from "jszip";
+import AddTargetPanel from "./ProposalEditorView/targets/New.tsx";
 
 /**
  * defines the user context type.
@@ -249,6 +250,11 @@ function App2(): ReactElement {
                         path: "proposal/:selectedProposalCode/targets",
                         element:<TargetPanel />,
                         errorElement: <ErrorPage />,
+                    },
+                    {
+                        path: "proposal/:selectedProposalCode/targets/new",
+                        element: <AddTargetPanel />,
+                        errorElement: <ErrorPage />
                     },
                     {
                         path: "proposal/:selectedProposalCode/goals",

--- a/src/main/webui/src/ProposalEditorView/targets/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/New.tsx
@@ -40,6 +40,8 @@ import * as React from "react";
 //move along, nothing to see here
 //@ts-ignore
 import A from 'aladin-lite';
+import TargetRaInput from "./TargetRaInput.tsx";
+import TargetDecInput from "./TargetDecInput.tsx";
 
 export let Aladin: AladinType;
 
@@ -54,6 +56,30 @@ const initialConfig: IAladinConfig = {
     showFullscreenControl: false,
     reticleColor: 'rgb(150, 255, 75)'
 };
+
+export interface NewTargetFormValues {
+    targetName: string
+    ra: string
+    dec: string
+    selectedEpoch: 'J2000'  // | 'B1950' | etc ??
+    sexagesimal: string
+    objectDescription?: string
+}
+
+/**
+ * generate new default name for a target
+ */
+export
+const generateTargetDefaultName = () : string => {
+    //reset the name to something generic + random suffix
+    let targetProxyName = "Target_";
+    let randNum = Math.random();
+    //convert the number into something using chars 0-9 A-Z
+    let hexString = randNum.toString(36);
+    targetProxyName += hexString.slice(6).toUpperCase();
+    return targetProxyName;
+}
+
 
 const TargetForm = (props: {closeModal: () => void}): ReactElement => {
 
@@ -88,45 +114,46 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
     // between fullscreen and not
     const isTablet = useMediaQuery('(max-width: 62em)');
 
-    const form = useForm({
+    const form = useForm<NewTargetFormValues>({
             initialValues: {
-                TargetName: "",
-                RA: "+00 00 00.000",
-                Dec: "+00 00 00.000",
-                SelectedEpoch: "J2000",
+                targetName: "",
+                ra: "+00 00 00.000",
+                dec: "+00 00 00.000",
+                selectedEpoch: "J2000",
                 sexagesimal: "00:00:00 +00:00:00"
             },
             validate: {
-                TargetName: (value) => (
+                targetName: (value) => (
                     value.length < 1 ? 'Name cannot be blank ' : nameUnique? null : 'Source name must be unique'),
-                RA: (value) => (
-                    value === null || value === undefined ?
-                        'RA cannot be blank':
-                        null)
+                ra: (value) => (
+                    value === null || value === undefined ? 'RA cannot be blank': null),
+                dec: (value) => (
+                    value === null || value === undefined ? 'Dec cannot be blank': null
+                )
             },
         });
 
     useEffect(() => {
-        setNameUnique(!targets.data?.find(t => t.name === form.getValues().TargetName));
-    }, [form.getValues().TargetName]);
+        setNameUnique(!targets.data?.find(t => t.name === form.getValues().targetName));
+    }, [form.getValues().targetName]);
 
-    const handleSubmission = form.onSubmit((val: newTargetData) => {
+    const handleSubmission = form.onSubmit((val: NewTargetFormValues) => {
         //remember to convert the sexagesimal to decimal
         const sourceCoords: EquatorialPoint = {
             "@type": "coords:EquatorialPoint",
             coordSys: spaceSystem.data!,
             lat: {
                 "@type": "ivoa:RealQuantity",
-                value: AstroLib.HmsToDeg(val.RA), unit: { value: "degrees" }
+                value: AstroLib.HmsToDeg(val.ra), unit: { value: "degrees" }
             },
             lon: {
                 "@type": "ivoa:RealQuantity",
-                value: AstroLib.DmsToDeg(val.Dec), unit: { value: "degrees" }
+                value: AstroLib.DmsToDeg(val.dec), unit: { value: "degrees" }
             }
         }
         const Target: CelestialTarget = {
             "@type": "proposal:CelestialTarget",
-            sourceName: val.TargetName,
+            sourceName: val.targetName,
             sourceCoordinates: sourceCoords,
             positionEpoch: { value: "J2000"}
         };
@@ -137,7 +164,7 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
         }, {
             onSuccess: () => {
                 queryClient.invalidateQueries().then();
-                notifySuccess("Target added", val.TargetName + " has been added successfully.");
+                notifySuccess("Target added", val.targetName + " has been added successfully.");
                 props.closeModal!();
             },
             onError: (error) =>
@@ -149,42 +176,33 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
      * handles the different mouse event types.
      * @param {React.MouseEvent<HTMLInputElement>} event the event that occurred.
      */
-    const HandleEvent = (event: MouseEvent<HTMLInputElement>) => {
+    const handleDoubleClick = (event: MouseEvent<HTMLInputElement>) => {
         const [ra, dec] = GetOffset(event);
         const [raCoords, decCoords] = Aladin.pix2world(ra, dec);
-        form.setFieldValue('RA', AstroLib.DegToHms(raCoords));
-        form.setFieldValue('Dec', AstroLib.DegToDms(decCoords));
+        form.setFieldValue('ra', AstroLib.DegToHms(raCoords));
+        form.setFieldValue('dec', AstroLib.DegToDms(decCoords));
         
         //we want to update the name if there is no entry OR if the entry is from the catalogue
-        if (form.values["TargetName"].slice(0,6) != "Target" && form.values["TargetName"].slice(0,8) != "Modified")
+        if (form.getValues().targetName.slice(0,6) != "Target" && form.getValues().targetName.slice(0,8) != "Modified")
         {
             //if we have a catalogue name, modify it to show that the target has moved
-            if(form.values["TargetName"] != ""){
-                ModifyTargetName(form.values["TargetName"]);               
+            if(form.getValues().targetName != ""){
+                ModifyTargetName(form.getValues().targetName);
             }
             //if we have no name, add one
             else{
-                GenerateTargetDefaultName();  
+                let generatedName = generateTargetDefaultName();
+
+                form.setFieldValue('targetName',generatedName);
+
+                //allow submission in case this was previously locked
+                setNameUnique(true);
             }
             
         }
     }
 
-    /**
-     * generate new default name for a target
-     */
-    const GenerateTargetDefaultName = () => {
-        //reset the name to something generic + random suffix
-        let targetProxyName = "Target_";
-        let randNum = Math.random();
-        //convert the number into something using chars 0-9 A-Z
-        let hexString = randNum.toString(36);
-        targetProxyName += hexString.slice(6).toUpperCase();
-        form.setFieldValue('TargetName', targetProxyName);
-        
-        //allow submission in case this was previously locked
-        setNameUnique(true);
-    }
+
     /**
      * modify the name for a target
      */
@@ -195,16 +213,10 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
         //convert the number into something using chars 0-9 A-Z
         let hexString = randNum.toString(36);
         targetProxyName += hexString.slice(6).toUpperCase();
-        form.setFieldValue('TargetName', targetProxyName);
+        form.setFieldValue('targetName', targetProxyName);
         
         //allow submission in case this was previously locked
         setNameUnique(true);
-    }
-    /**
-     * update the Aladin viewport to the new RA and Dec
-     */
-    const UpdateAladinRaDec = () => {
-        Aladin.gotoRaDec(Number(AstroLib.HmsToDeg(form.getValues().RA)), AstroLib.DmsToDeg(form.getValues().Dec));
     }
 
     const responsiveSpan = {base: 2, md: 1}
@@ -237,141 +249,15 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
                             placeholder="User provided or use the SIMBAD search"
                             description={nameUnique ? "Something descriptive is recommended" : null}
                             error={nameUnique ? null :
-                                form.getValues().TargetName + " is in use, choose another name"}
+                                form.getValues().targetName + " is in use, choose another name"}
                             inputWrapperOrder={['label', 'description', 'error', 'input']}
-                            value={form.getValues().TargetName}
+                            value={form.getValues().targetName}
                             onChange={(e: React.FormEvent<HTMLInputElement>) =>{
-                                form.setFieldValue('TargetName', e.currentTarget.value)
+                                form.setFieldValue('targetName', e.currentTarget.value)
                             }}
                         />
-                        <TextInput
-                            //hideControls
-                            label={"RA"}
-                            //decimalScale={6}
-                            //min={0}
-                            //max={360}
-                            //allowNegative={false}
-                            //suffix="°"
-                            {...form.getInputProps("RA")}
-                            onBlur={(e) => {
-                                if (form.getInputProps("RA").onBlur) {
-                                    form.getInputProps("RA").onBlur(e);
-                                }
-                                //get the live value from the input
-                                let raValue: string = form.getValues()["RA"];
-                                //regex to check for sexagesimal input
-                                const regexpsgm = new RegExp(/(\d{1,3})\D(\d{1,2})\D(\d{1,2}(\.\d+)[sS]*)/);
-                                //regex to check for decimal input
-                                const regexdec = new RegExp(/[0-9]*\.[0-9]*/);
-                                //if we have sexagesimal input accept as is
-                                if(regexpsgm.test(raValue))
-                                {
-                                    //set the field value to the input
-                                    form.setFieldValue("RA", raValue);
-                                    //if we have no name for this object, generate one
-                                    if(form.values["TargetName"] == "" )
-                                    {
-                                        GenerateTargetDefaultName();
-                                    } 
-                                    //update the Aladin viewport                              
-                                    UpdateAladinRaDec();
-                                }
-                                //if we have decimal
-                                else if(regexdec.test(raValue))
-                                {
-                                    //convert the decimal to sexagesimal
-                                    raValue = String(AstroLib.DegToHms(parseFloat(raValue)));
-                                    form.setFieldValue("RA", raValue);
-                                    //if we have no name for this object, generate one
-                                    if(form.values["TargetName"] == "")
-                                    {
-                                        GenerateTargetDefaultName();
-                                    } 
-                                    //update the Aladin viewport                              
-                                    UpdateAladinRaDec();
-                                }
-                                else
-                                {
-                                    //if we have no valid input, reset the field - preventing submission
-                                    form.setFieldValue("TargetName", "");
-                                }
-                           
-                                //update the Aladin viewport
-                                UpdateAladinRaDec();
-                            }}
-                        />
-                        <Text
-                            size={"xs"}
-                            c={"gray.6"}
-                            style={{margin: "-4px 0px 0px 12px"}}
-                        >
-                            {AstroLib.HmsToDeg(form.getValues()["RA"])}°
-                        </Text>
-                        <TextInput
-                            //hideControls
-                            label={"Dec"}
-                            //decimalScale={6}
-                            min={-90}
-                            max={90}
-                            //suffix="°"
-                            {...form.getInputProps("Dec")}
-                            onBlur={(e) => {
-                                if (form.getInputProps("Dec").onBlur) {
-                                    form.getInputProps("Dec").onBlur(e);
-                                }
-                                //get the live value from the input
-                                let decValue: string = form.getValues()["Dec"];
-                                
-                                //regex to check for sexagesimal input
-                                const regexpsgm = new RegExp(/(\d{1,2})\D(\d{1,2})\D(\d{1,2}(\.\d+)[sS]*)/);
-                                //regex to check for decimal input
-                                const regexdec = new RegExp(/[0-9]*\.[0-9]*/);
-
-                                //if we have sexagesimal input accept as is
-                                if(regexpsgm.test(decValue))
-                                {
-                                    //set the field value to the input
-                                    form.setFieldValue("Dec", decValue);
-                                    //if we have no name for this object, generate one
-                                    if(form.values["TargetName"] == "")
-                                    {
-                                        GenerateTargetDefaultName();
-                                    } 
-
-                                    //update the Aladin viewport                              
-                                    UpdateAladinRaDec();
-                                } 
-                                //if we have decimal
-                                else if(regexdec.test(decValue))
-                                {
-                                    //convert the decimal to sexagesimal
-                                    decValue = String(AstroLib.DegToDms(parseFloat(decValue)));
-                                    form.setFieldValue("Dec", decValue);
-                                    //if we have no name for this object, generate one
-                                    if(form.values["TargetName"] == "")
-                                    {
-                                        GenerateTargetDefaultName();
-                                    } 
-                                    //update the Aladin viewport                              
-                                    UpdateAladinRaDec();
-                                }
-                                else
-                                {
-                                    //if we have no valid input, reset the field - preventing submission
-                                    form.setFieldValue("TargetName", "");
-
-                                }
-                                                                                  
-                                
-                            }}
-                        />
-                        <Text
-                            size={"xs"}
-                            c={"gray.6"}
-                            style={{margin: "-4px 0px 0px 12px"}}
-                        >
-                            {AstroLib.DmsToDeg(form.getValues()["Dec"])}°
-                        </Text>
+                        <TargetRaInput form={form} setNameUnique={setNameUnique} />
+                        <TargetDecInput form={form} setNameUnique={setNameUnique} />
                         <SubmitButton
                             toolTipLabel={"Save this target"}
                             disabled={!form.isValid()}
@@ -387,8 +273,7 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
                 >
                     <div
                         id="aladin-lite-div"
-
-                        onDoubleClick={HandleEvent}
+                        onDoubleClick={handleDoubleClick}
                     >
                     </div>
                 </Fieldset>
@@ -427,23 +312,5 @@ export default function AddTargetModal(props: {proposalTitle: string}): ReactEle
     );
 }
 
-/**
- * the new data required for target form.
- *
- * @param SelectedEpoch which epoch to use.
- * @param RA the longitude
- * @param Dec the latitude
- * @param TargetName the name of the target
- * @param sexagesimal sexagesimal string representation of Ra & Dec
- * @param objectDescription description of the target object type from SIMBAD, optional
- */
-export type newTargetData = {
-    SelectedEpoch: string;
-    RA: string;
-    Dec: string;
-    TargetName: string
-    sexagesimal: string
-    objectDescription?: string
-}
 
 

--- a/src/main/webui/src/ProposalEditorView/targets/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/New.tsx
@@ -2,7 +2,6 @@ import {Modal, TextInput, Stack, Fieldset, Grid, rem, Text, Loader} from "@manti
 import {useForm} from "@mantine/form";
 import {useDisclosure, useMediaQuery} from "@mantine/hooks";
 import {
-    MouseEvent,
     ReactElement,
     useEffect,
     useState
@@ -27,7 +26,6 @@ import {
 } from './aladinTypes.tsx';
 import { ALADIN_SRC_URL } from 'src/constants.tsx';
 import {
-    GetOffset,
     LoadScriptIntoDOM
 } from './aladinHelperMethods.tsx';
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
@@ -187,13 +185,14 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
         })
     });
 
-    /**
-     * handles the different mouse event types.
-     * @param {React.MouseEvent<HTMLInputElement>} event the event that occurred.
-     */
-    const handleMouseUpCapture = (event: MouseEvent<HTMLInputElement>) => {
-        const [ra, dec] = GetOffset(event);
-        const [raCoords, decCoords] = Aladin.pix2world(ra, dec);
+    const handleDoubleClick = () => {
+
+        //Notice: on double-click the sky atlas centers the view on the mouse pointer location
+        // therefore we only need to extract the central location coordinates
+
+        const [raCoords, decCoords] = Aladin.getRaDec(); //gets the view central coordinates
+
+        //DJW: Astrolib DegToHms prepend sign issue
         form.setFieldValue('ra', AstroLib.DegToHms(raCoords).slice(1));
         form.setFieldValue('dec', AstroLib.DegToDms(decCoords));
         
@@ -288,7 +287,7 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
                 >
                     <div
                         id="aladin-lite-div"
-                        onMouseUpCapture={handleMouseUpCapture}
+                        onDoubleClick={handleDoubleClick}
                     >
                     </div>
                 </Fieldset>

--- a/src/main/webui/src/ProposalEditorView/targets/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/New.tsx
@@ -1,4 +1,4 @@
-import { TextInput, Stack, Fieldset, Grid, rem, Text, Loader} from "@mantine/core";
+import {TextInput, Stack, Fieldset, Grid, rem, Text, Loader, Group} from "@mantine/core";
 import {useForm} from "@mantine/form";
 import { useMediaQuery} from "@mantine/hooks";
 import {
@@ -108,8 +108,9 @@ function AddTargetPanel(): ReactElement {
         pathParams: {frameCode: 'ICRS'}
     })
 
-    //media query used to conditionally set the height of Aladin viewer
-    const isTablet = useMediaQuery('(max-width: 62em)');
+    //media queries to attempt to make the page look okay at different screen widths
+    const isTablet = useMediaQuery('(max-width: 90em)');
+    const isWide = useMediaQuery("(max-width: 2000px)");
 
     const form = useForm<NewTargetFormValues>({
             initialValues: {
@@ -233,59 +234,64 @@ function AddTargetPanel(): ReactElement {
         setNameUnique(true);
     }
 
-    const responsiveSpan = {base: 2, md: 1}
-
     if (targets.isLoading || spaceSystem.isLoading) {
         return (
             <Loader />
         )
     }
 
+    let responsiveSpan = {base: 12, xl: 6}
+
     return (
-        <PanelFrame>
+        <PanelFrame
+            mx={isWide ? "0" : "10%"}
+        >
             <EditorPanelHeader
                 proposalCode={Number(selectedProposalCode)}
                 panelHeading={"Add a Target"}
             />
-            <Grid columns={2}>
-                <Grid.Col span={2}>
+            <Grid columns={12}>
+                <Grid.Col span={12}>
                     <Fieldset legend={"User Information"}>
                         <Text size={"xs"} c={"gray.6"}>Click on a tab to toggle its content</Text>
-                        <SimbadSearchHelp/>
-                    </Fieldset>
-                </Grid.Col>
-                <Grid.Col span={2}>
-                    <Fieldset legend={"SIMBAD search"} pt={10}>
-                        <SimbadSearch form={form}/>
+                        <SimbadSearchHelp largeScrollArea={!isWide}/>
                     </Fieldset>
                 </Grid.Col>
                 <Grid.Col span={responsiveSpan}>
-                    <Fieldset legend={"Target Form"}>
-                        <form onSubmit={handleSubmission}>
-                            <Stack gap={"xs"}>
-                                <TextInput
-                                    label="Name your target"
-                                    placeholder="User provided or use the SIMBAD search"
-                                    description={nameUnique ? "Something descriptive is recommended" : null}
-                                    error={nameUnique ? null :
-                                        form.getValues().targetName + " is in use, choose another name"}
-                                    inputWrapperOrder={['label', 'description', 'error', 'input']}
-                                    value={form.getValues().targetName}
-                                    onChange={(e: React.FormEvent<HTMLInputElement>) =>{
-                                        form.setFieldValue('targetName', e.currentTarget.value)
-                                    }}
-                                />
-                                <TargetRaInput form={form} setNameUnique={setNameUnique} />
-                                <TargetDecInput form={form} setNameUnique={setNameUnique} />
+                    <Stack gap={"xs"}>
+                        <Fieldset legend={"SIMBAD search"} pt={10}>
+                            <SimbadSearch form={form}/>
+                        </Fieldset>
+                        <Fieldset legend={"Target Form"}>
+                            <form onSubmit={handleSubmission}>
+                                <Stack gap={"xs"}>
+                                    <TextInput
+                                        label="Name your target"
+                                        placeholder="User provided or use the SIMBAD search"
+                                        description={nameUnique ? "Something descriptive is recommended" : null}
+                                        error={nameUnique ? null :
+                                            form.getValues().targetName + " is in use, choose another name"}
+                                        inputWrapperOrder={['label', 'description', 'error', 'input']}
+                                        value={form.getValues().targetName}
+                                        onChange={(e: React.FormEvent<HTMLInputElement>) =>{
+                                            form.setFieldValue('targetName', e.currentTarget.value)
+                                        }}
+                                    />
+                                    <TargetRaInput form={form} setNameUnique={setNameUnique} />
+                                    <TargetDecInput form={form} setNameUnique={setNameUnique} />
 
-                                <FormSubmitButton form={form} />
-                                <CancelButton
-                                    toolTipLabel={"Go back without saving"}
-                                    onClick={() => navigate("../", {relative:"path"})}
-                                />
-                            </Stack>
-                        </form>
-                    </Fieldset>
+                                    <Group justify={"flex-end"}>
+                                        <FormSubmitButton form={form} />
+                                        <CancelButton
+                                            toolTipLabel={"Go back without saving"}
+                                            onClick={() => navigate("../", {relative:"path"})}
+                                        />
+                                    </Group>
+
+                                </Stack>
+                            </form>
+                        </Fieldset>
+                    </Stack>
                 </Grid.Col>
                 <Grid.Col span={responsiveSpan}>
                     <Fieldset

--- a/src/main/webui/src/ProposalEditorView/targets/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/New.tsx
@@ -47,7 +47,6 @@ export let Aladin: AladinType;
 
 // setup for Aladin viewer in Polaris - settings where the defaults aren't right for us
 const initialConfig: IAladinConfig = {
-    cooFrame: 'ICRSd',
     projection: 'STG',
     showFrame: false,
     showZoomControl: false,
@@ -117,8 +116,8 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
     const form = useForm<NewTargetFormValues>({
             initialValues: {
                 targetName: "",
-                ra: "+00 00 00.000",
-                dec: "+00 00 00.000",
+                ra: "",
+                dec: "",
                 selectedEpoch: "J2000",
                 sexagesimal: "00:00:00 +00:00:00"
             },
@@ -126,10 +125,16 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
                 targetName: (value) => (
                     value.length < 1 ? 'Name cannot be blank ' : nameUnique? null : 'Source name must be unique'),
                 ra: (value) => (
-                    value === null || value === undefined ? 'RA cannot be blank': null),
-                dec: (value) => (
-                    value === null || value === undefined ? 'Dec cannot be blank': null
-                )
+                    value === null || value === '' ? 'RA cannot be blank': null),
+                dec: (value) => {
+                    if (value === null || value === '') return 'Dec cannot be blank'
+                    const validSgm = /^[-+]?\d{1,2}([ :])\d{1,2}([ :])\d{1,2}(?:[.]\d+)?$/
+                    if (!validSgm.test(value)) return 'Invalid value format'
+                    let noDecimal = !value.includes('.')
+                    let decDegrees = AstroLib.DmsToDeg(noDecimal ? value + '.0' : value);
+                    if (decDegrees < -90 || decDegrees > 90 ) return 'Value out-of-range'
+                    return null
+                }
             },
         });
 

--- a/src/main/webui/src/ProposalEditorView/targets/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/New.tsx
@@ -1,6 +1,6 @@
-import {Modal, TextInput, Stack, Fieldset, Grid, rem, Text, Loader} from "@mantine/core";
+import { TextInput, Stack, Fieldset, Grid, rem, Text, Loader} from "@mantine/core";
 import {useForm} from "@mantine/form";
-import {useDisclosure, useMediaQuery} from "@mantine/hooks";
+import { useMediaQuery} from "@mantine/hooks";
 import {
     ReactElement,
     useEffect,
@@ -16,9 +16,8 @@ import {
     useSpaceSystemResourceGetSpaceSystem
 } from "src/generated/proposalToolComponents.ts";
 import {useQueryClient} from "@tanstack/react-query";
-import {useParams} from "react-router-dom";
-import AddButton from 'src/commonButtons/add';
-import { SubmitButton } from 'src/commonButtons/save';
+import {useNavigate, useParams} from "react-router-dom";
+import {FormSubmitButton} from 'src/commonButtons/save';
 import "./aladin.css";
 import {
     AladinType,
@@ -40,6 +39,8 @@ import * as React from "react";
 import A from 'aladin-lite';
 import TargetRaInput from "./TargetRaInput.tsx";
 import TargetDecInput from "./TargetDecInput.tsx";
+import {EditorPanelHeader, PanelFrame} from "../../commonPanel/appearance.tsx";
+import CancelButton from "../../commonButtons/cancel.tsx";
 
 export let Aladin: AladinType;
 
@@ -77,8 +78,8 @@ const generateTargetDefaultName = () : string => {
     return targetProxyName;
 }
 
-
-const TargetForm = (props: {closeModal: () => void}): ReactElement => {
+export default
+function AddTargetPanel(): ReactElement {
 
     useEffect(() => {
         const bodyElement =
@@ -91,6 +92,7 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
             })
     }, []);
 
+    const navigate = useNavigate();
     const queryClient = useQueryClient();
     const {selectedProposalCode} = useParams();
     const [nameUnique, setNameUnique] = useState(true);
@@ -106,8 +108,7 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
         pathParams: {frameCode: 'ICRS'}
     })
 
-    //media query used to conditionally set the height of Aladin when the modal toggles
-    // between fullscreen and not
+    //media query used to conditionally set the height of Aladin viewer
     const isTablet = useMediaQuery('(max-width: 62em)');
 
     const form = useForm<NewTargetFormValues>({
@@ -177,7 +178,7 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
             onSuccess: () => {
                 queryClient.invalidateQueries().then();
                 notifySuccess("Target added", val.targetName + " has been added successfully.");
-                props.closeModal!();
+                navigate("../", {relative:"path"})
             },
             onError: (error) =>
                 notifyError("Failed to add Target", getErrorMessage(error))
@@ -241,89 +242,67 @@ const TargetForm = (props: {closeModal: () => void}): ReactElement => {
     }
 
     return (
-        <Grid columns={2}>
-            <Grid.Col span={2}>
-                <Fieldset legend={"User Information"}>
-                    <Text size={"xs"} c={"gray.6"}>Click on a tab to toggle its content</Text>
-                    <SimbadSearchHelp/>
-                </Fieldset>
-            </Grid.Col>
-            <Grid.Col span={2}>
-                <Fieldset legend={"SIMBAD search"} pt={10}>
-                    <SimbadSearch form={form}/>
-                </Fieldset>
-            </Grid.Col>
-            <Grid.Col span={responsiveSpan}>
-                <Fieldset legend={"Target Form"}>
-                <form onSubmit={handleSubmission}>
-                    <Stack gap={"xs"}>
-                        <TextInput
-                            label="Name your target"
-                            placeholder="User provided or use the SIMBAD search"
-                            description={nameUnique ? "Something descriptive is recommended" : null}
-                            error={nameUnique ? null :
-                                form.getValues().targetName + " is in use, choose another name"}
-                            inputWrapperOrder={['label', 'description', 'error', 'input']}
-                            value={form.getValues().targetName}
-                            onChange={(e: React.FormEvent<HTMLInputElement>) =>{
-                                form.setFieldValue('targetName', e.currentTarget.value)
-                            }}
-                        />
-                        <TargetRaInput form={form} setNameUnique={setNameUnique} />
-                        <TargetDecInput form={form} setNameUnique={setNameUnique} />
-                        <SubmitButton
-                            toolTipLabel={"Save this target"}
-                            disabled={!form.isValid()}
-                        />
-                    </Stack>
-                </form>
-                </Fieldset>
-            </Grid.Col>
-            <Grid.Col span={responsiveSpan}>
-                <Fieldset
-                    legend={"Aladin Sky Atlas"}
-                    style={{height: isTablet? rem(350) : "100%"}}
-                >
-                    <div
-                        id="aladin-lite-div"
-                        onDoubleClick={handleDoubleClick}
+        <PanelFrame>
+            <EditorPanelHeader
+                proposalCode={Number(selectedProposalCode)}
+                panelHeading={"Add a Target"}
+            />
+            <Grid columns={2}>
+                <Grid.Col span={2}>
+                    <Fieldset legend={"User Information"}>
+                        <Text size={"xs"} c={"gray.6"}>Click on a tab to toggle its content</Text>
+                        <SimbadSearchHelp/>
+                    </Fieldset>
+                </Grid.Col>
+                <Grid.Col span={2}>
+                    <Fieldset legend={"SIMBAD search"} pt={10}>
+                        <SimbadSearch form={form}/>
+                    </Fieldset>
+                </Grid.Col>
+                <Grid.Col span={responsiveSpan}>
+                    <Fieldset legend={"Target Form"}>
+                        <form onSubmit={handleSubmission}>
+                            <Stack gap={"xs"}>
+                                <TextInput
+                                    label="Name your target"
+                                    placeholder="User provided or use the SIMBAD search"
+                                    description={nameUnique ? "Something descriptive is recommended" : null}
+                                    error={nameUnique ? null :
+                                        form.getValues().targetName + " is in use, choose another name"}
+                                    inputWrapperOrder={['label', 'description', 'error', 'input']}
+                                    value={form.getValues().targetName}
+                                    onChange={(e: React.FormEvent<HTMLInputElement>) =>{
+                                        form.setFieldValue('targetName', e.currentTarget.value)
+                                    }}
+                                />
+                                <TargetRaInput form={form} setNameUnique={setNameUnique} />
+                                <TargetDecInput form={form} setNameUnique={setNameUnique} />
+
+                                <FormSubmitButton form={form} />
+                                <CancelButton
+                                    toolTipLabel={"Go back without saving"}
+                                    onClick={() => navigate("../", {relative:"path"})}
+                                />
+                            </Stack>
+                        </form>
+                    </Fieldset>
+                </Grid.Col>
+                <Grid.Col span={responsiveSpan}>
+                    <Fieldset
+                        legend={"Aladin Sky Atlas"}
+                        style={{height: isTablet? rem(350) : "100%"}}
                     >
-                    </div>
-                </Fieldset>
-            </Grid.Col>
-        </Grid>
+                        <div
+                            id="aladin-lite-div"
+                            onDoubleClick={handleDoubleClick}
+                        >
+                        </div>
+                    </Fieldset>
+                </Grid.Col>
+            </Grid>
+        </PanelFrame>
     );
 };
-
-
-/**
- * On click the add button displays the add new target modal.
- *
- * @return a React Element of a visible add button and hidden modal.
- *
- */
-export default function AddTargetModal(props: {proposalTitle: string}): ReactElement {
-    const [opened, { close, open }] = useDisclosure();
-    const isMobile = useMediaQuery('(max-width: 75em)');
-
-    return (
-        <>
-            <AddButton
-                onClick={open}
-                toolTipLabel={"Add new target."}
-            />
-            <Modal title={`Add a Target to '${props.proposalTitle}'`}
-                   opened={opened}
-                   onClose={() => {close();}}
-                   fullScreen={isMobile}
-                   size={"60%"}
-                   closeOnClickOutside={false}
-            >
-                <TargetForm closeModal={close}/>
-            </Modal>
-        </>
-    );
-}
 
 
 

--- a/src/main/webui/src/ProposalEditorView/targets/New.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/New.tsx
@@ -81,7 +81,6 @@ const generateTargetDefaultName = () : string => {
 const TargetForm = (props: {closeModal: () => void}): ReactElement => {
 
     useEffect(() => {
-
         const bodyElement =
             document.getElementsByTagName('BODY')[0] as HTMLElement;
 

--- a/src/main/webui/src/ProposalEditorView/targets/TargetDecInput.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetDecInput.tsx
@@ -1,0 +1,91 @@
+import {ReactElement} from "react";
+import {Stack, Text, TextInput} from "@mantine/core";
+import {AstroLib} from "@tsastro/astrolib";
+import * as React from "react";
+import {Aladin, generateTargetDefaultName} from "./New.tsx";
+import {UseFormReturnType} from "@mantine/form";
+
+export default
+function TargetDecInput(p: {
+    form: UseFormReturnType<any>
+    setNameUnique: React.Dispatch<React.SetStateAction<boolean>>
+}) : ReactElement {
+
+    return (
+        <Stack>
+            <TextInput
+                label={"Dec"}
+                {...p.form.getInputProps("dec")}
+                onBlur={(e) => {
+                    if (p.form.getInputProps("dec").onBlur) {
+                        p.form.getInputProps("dec").onBlur(e);
+                    }
+                    //get the live value from the input
+                    let decValue: string = p.form.getValues().dec;
+
+                    //regex to check for sexagesimal input
+                    const regexpsgm = new RegExp(/(\d{1,2})\D(\d{1,2})\D(\d{1,2}(\.\d+)[sS]*)/);
+                    //regex to check for decimal input
+                    const regexdec = new RegExp(/[0-9]*\.[0-9]*/);
+
+                    //if we have sexagesimal input use as is
+                    if(regexpsgm.test(decValue))
+                    {
+                        //set the field value to the input
+                        p.form.setFieldValue("dec", decValue);
+                        //if we have no name for this object, generate one
+                        if(p.form.getValues().targetName == "")
+                        {
+                            let generatedName = generateTargetDefaultName();
+
+                            p.form.setFieldValue('targetName',generatedName);
+
+                            //allow submission in case this was previously locked
+                            p.setNameUnique(true);
+                        }
+
+                        //update the Aladin viewport
+                        Aladin.gotoRaDec(
+                            Number(AstroLib.HmsToDeg(p.form.getValues().ra)),
+                            AstroLib.DmsToDeg(p.form.getValues().dec)
+                        );
+                    }
+                    //if we have decimal
+                    else if(regexdec.test(decValue))
+                    {
+                        //convert the decimal to sexagesimal
+                        decValue = String(AstroLib.DegToDms(parseFloat(decValue)));
+                        p.form.setFieldValue("dec", decValue);
+                        //if we have no name for this object, generate one
+                        if(p.form.getValues().targetName == "")
+                        {
+                            let generatedName = generateTargetDefaultName();
+
+                            p.form.setFieldValue('targetName',generatedName);
+
+                            //allow submission in case this was previously locked
+                            p.setNameUnique(true);
+                        }
+                        //update the Aladin viewport
+                        Aladin.gotoRaDec(
+                            Number(AstroLib.HmsToDeg(p.form.getValues().ra)),
+                            AstroLib.DmsToDeg(p.form.getValues().dec)
+                        );
+                    }
+                    else
+                    {
+                        //if we have no valid input, reset the field - preventing submission
+                        p.form.setFieldValue("targetName", "");
+                    }
+                }}
+            />
+            <Text
+                size={"xs"}
+                c={"gray.6"}
+                style={{margin: "-4px 0px 0px 12px"}}
+            >
+                {AstroLib.DmsToDeg(p.form.getValues().dec)}°
+            </Text>
+        </Stack>
+    )
+}

--- a/src/main/webui/src/ProposalEditorView/targets/TargetDecInput.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetDecInput.tsx
@@ -20,9 +20,9 @@ function TargetDecInput(p: {
                 {...p.form.getInputProps("dec")}
                 error={invalidMessage.length > 0 ? invalidMessage : null}
                 onChange={e => {
-                    if (p.form.getInputProps("dec").onChange) {
+                    if (p.form.getInputProps("dec").onChange)
                         p.form.getInputProps("dec").onChange(e);
-                    }
+
 
                     const nonValidChars = /[^0-9 :+-.]/
 
@@ -56,11 +56,9 @@ function TargetDecInput(p: {
                     }
 
                     if (testSgm) {
-                        //problem with Astrolib.DmsToDeg when no decimal point given so just append '.0'
-                        //if no fractional part is given
-                        if (!decValue.includes('.')) {
-                            decValue += '.0'
-                        }
+                        //when no fractional part is given Astrolib gives up, so we append for semantics here
+                        if (!decValue.includes('.')) decValue += '.0'
+
                     }
 
                     //check valid range for declination
@@ -72,7 +70,7 @@ function TargetDecInput(p: {
                     }
 
                     if (testDeg) {
-                        decValue = String(AstroLib.DegToDms(parseFloat(decValue)));
+                        decValue = AstroLib.DegToDms(parseFloat(decValue));
                     }
 
                     p.form.setFieldValue("dec", decValue);

--- a/src/main/webui/src/ProposalEditorView/targets/TargetRaInput.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetRaInput.tsx
@@ -1,82 +1,90 @@
-import {ReactElement} from "react";
+import {Dispatch, ReactElement, SetStateAction, useState} from "react";
 import {Stack, Text, TextInput} from "@mantine/core";
 import {AstroLib} from "@tsastro/astrolib";
 import {UseFormReturnType} from "@mantine/form";
 import {Aladin, generateTargetDefaultName, NewTargetFormValues} from "./New.tsx";
-import * as React from "react";
 
 export default
 function TargetRaInput(p: {
     form: UseFormReturnType<NewTargetFormValues>
-    setNameUnique: React.Dispatch<React.SetStateAction<boolean>>
+    setNameUnique: Dispatch<SetStateAction<boolean>>
 }) : ReactElement {
 
+    const [invalidMessage, setInvalidMessage] = useState("");
+
     return(
-        <Stack>
+        <Stack gap={"xs"}>
             <TextInput
                 label={"RA"}
+                placeholder={"e.g., 15 30 00.0 OR 225.5"}
                 {...p.form.getInputProps("ra")}
+                error={invalidMessage.length > 0 ? invalidMessage : null}
+                onChange={e => {
+                    if (p.form.getInputProps("ra").onChange)
+                        p.form.getInputProps("ra").onChange(e);
+
+                    const nonValidChars = /[^0-9 :.]/
+
+                    if (nonValidChars.test(e.currentTarget.value)) {
+                        setInvalidMessage("Invalid character entered")
+                    } else {
+                        setInvalidMessage("")
+                    }
+                }}
                 onBlur={(e) => {
                     if (p.form.getInputProps("ra").onBlur) {
                         p.form.getInputProps("ra").onBlur(e);
                     }
                     //get the live value from the input
-                    let raValue: string = p.form.getValues()["ra"];
+                    let raValue: string = e.currentTarget.value;
+
+                    if (raValue.length === 0) return
+
                     //regex to check for sexagesimal input
-                    const regexpsgm = new RegExp(/(\d{1,3})\D(\d{1,2})\D(\d{1,2}(\.\d+)[sS]*)/);
+                    const validRaSgm = /^\d{1,2}([ :])\d{1,2}([ :])\d{1,2}(?:[.]\d+)?$/
                     //regex to check for decimal input
-                    const regexdec = new RegExp(/[0-9]*\.[0-9]*/);
+                    const validRaDegrees = /^\d{1,3}(?:[.]\d+)?$/
 
-                    //if we have sexagesimal input use as is
-                    if(regexpsgm.test(raValue))
-                    {
-                        //set the field value to the input
-                        p.form.setFieldValue("ra", raValue);
-                        //if we have no name for this object, generate one
-                        if(p.form.getValues().targetName == "" )
-                        {
-                            let generatedName = generateTargetDefaultName();
-                            p.form.setFieldValue('targetName',generatedName);
+                    let testSgm = validRaSgm.test(raValue)
+                    let testDeg = validRaDegrees.test(raValue)
 
-                            //allow submission in case this was previously locked
-                            p.setNameUnique(true);
-                        }
-                        //update the Aladin viewport
-                        Aladin.gotoRaDec(
-                            Number(AstroLib.HmsToDeg(p.form.getValues().ra)),
-                            AstroLib.DmsToDeg(p.form.getValues().dec)
-                        );
+                    if (!testSgm && !testDeg) {
+                        setInvalidMessage("Invalid number format")
+                        return
                     }
-                    //if we have decimal
-                    else if(regexdec.test(raValue))
-                    {
-                        //convert the decimal to sexagesimal
-                        raValue = String(AstroLib.DegToHms(parseFloat(raValue)));
-                        p.form.setFieldValue("RA", raValue);
-                        //if we have no name for this object, generate one
-                        if(p.form.getValues().targetName == "")
-                        {
-                            let generatedName = generateTargetDefaultName();
-                            p.form.setFieldValue('targetName', generatedName);
 
-                            //allow submission in case this was previously locked
-                            p.setNameUnique(true);
-                        }
-                        //update the Aladin viewport
-                        Aladin.gotoRaDec(
-                            Number(AstroLib.HmsToDeg(p.form.getValues().ra)),
-                            AstroLib.DmsToDeg(p.form.getValues().dec)
-                        );
+                    if (testSgm) {
+                        //when no fractional part is given Astrolib gives up, so we append for semantics here
+                        if (!raValue.includes('.')) raValue += '.0'
                     }
-                    else
+
+                    let raFloatDegrees = testDeg ? parseFloat(raValue) : AstroLib.HmsToDeg(raValue)
+
+                    if (raFloatDegrees < 0 || raFloatDegrees > 360) {
+                        setInvalidMessage("Value out-of-bounds")
+                        return
+                    }
+
+                    if (testDeg) {
+                        //remove the redundant '+' prepended on string from Astrolib
+                        raValue = AstroLib.DegToHms(parseFloat(raValue)).slice(1)
+                    }
+
+                    p.form.setFieldValue('ra', raValue);
+
+                    //if we have no name for this object, generate one
+                    if(p.form.getValues().targetName == "" )
                     {
-                        //if we have no valid input, reset the field - preventing submission
-                        p.form.setFieldValue("targetName", "");
+                        let generatedName = generateTargetDefaultName();
+                        p.form.setFieldValue('targetName',generatedName);
+
+                        //allow submission in case this was previously locked
+                        p.setNameUnique(true);
                     }
 
                     //update the Aladin viewport
                     Aladin.gotoRaDec(
-                        Number(AstroLib.HmsToDeg(p.form.getValues().ra)),
+                        Number(AstroLib.HmsToDeg(raValue)),
                         AstroLib.DmsToDeg(p.form.getValues().dec)
                     );
                 }}

--- a/src/main/webui/src/ProposalEditorView/targets/TargetRaInput.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetRaInput.tsx
@@ -1,0 +1,94 @@
+import {ReactElement} from "react";
+import {Stack, Text, TextInput} from "@mantine/core";
+import {AstroLib} from "@tsastro/astrolib";
+import {UseFormReturnType} from "@mantine/form";
+import {Aladin, generateTargetDefaultName, NewTargetFormValues} from "./New.tsx";
+import * as React from "react";
+
+export default
+function TargetRaInput(p: {
+    form: UseFormReturnType<NewTargetFormValues>
+    setNameUnique: React.Dispatch<React.SetStateAction<boolean>>
+}) : ReactElement {
+
+    return(
+        <Stack>
+            <TextInput
+                label={"RA"}
+                {...p.form.getInputProps("ra")}
+                onBlur={(e) => {
+                    if (p.form.getInputProps("ra").onBlur) {
+                        p.form.getInputProps("ra").onBlur(e);
+                    }
+                    //get the live value from the input
+                    let raValue: string = p.form.getValues()["ra"];
+                    //regex to check for sexagesimal input
+                    const regexpsgm = new RegExp(/(\d{1,3})\D(\d{1,2})\D(\d{1,2}(\.\d+)[sS]*)/);
+                    //regex to check for decimal input
+                    const regexdec = new RegExp(/[0-9]*\.[0-9]*/);
+
+                    //if we have sexagesimal input use as is
+                    if(regexpsgm.test(raValue))
+                    {
+                        //set the field value to the input
+                        p.form.setFieldValue("ra", raValue);
+                        //if we have no name for this object, generate one
+                        if(p.form.getValues().targetName == "" )
+                        {
+                            let generatedName = generateTargetDefaultName();
+                            p.form.setFieldValue('targetName',generatedName);
+
+                            //allow submission in case this was previously locked
+                            p.setNameUnique(true);
+                        }
+                        //update the Aladin viewport
+                        Aladin.gotoRaDec(
+                            Number(AstroLib.HmsToDeg(p.form.getValues().ra)),
+                            AstroLib.DmsToDeg(p.form.getValues().dec)
+                        );
+                    }
+                    //if we have decimal
+                    else if(regexdec.test(raValue))
+                    {
+                        //convert the decimal to sexagesimal
+                        raValue = String(AstroLib.DegToHms(parseFloat(raValue)));
+                        p.form.setFieldValue("RA", raValue);
+                        //if we have no name for this object, generate one
+                        if(p.form.getValues().targetName == "")
+                        {
+                            let generatedName = generateTargetDefaultName();
+                            p.form.setFieldValue('targetName', generatedName);
+
+                            //allow submission in case this was previously locked
+                            p.setNameUnique(true);
+                        }
+                        //update the Aladin viewport
+                        Aladin.gotoRaDec(
+                            Number(AstroLib.HmsToDeg(p.form.getValues().ra)),
+                            AstroLib.DmsToDeg(p.form.getValues().dec)
+                        );
+                    }
+                    else
+                    {
+                        //if we have no valid input, reset the field - preventing submission
+                        p.form.setFieldValue("targetName", "");
+                    }
+
+                    //update the Aladin viewport
+                    Aladin.gotoRaDec(
+                        Number(AstroLib.HmsToDeg(p.form.getValues().ra)),
+                        AstroLib.DmsToDeg(p.form.getValues().dec)
+                    );
+                }}
+            />
+            <Text
+                size={"xs"}
+                c={"gray.6"}
+                style={{margin: "-4px 0px 0px 12px"}}
+            >
+                {AstroLib.HmsToDeg(p.form.getValues().ra)}°
+            </Text>
+        </Stack>
+
+    )
+}

--- a/src/main/webui/src/ProposalEditorView/targets/TargetRaInput.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetRaInput.tsx
@@ -66,7 +66,7 @@ function TargetRaInput(p: {
                     }
 
                     if (testDeg) {
-                        //remove the redundant '+' prepended on string from Astrolib
+                        //DJW: Astrolib DegToHms prepend sign issue
                         raValue = AstroLib.DegToHms(parseFloat(raValue)).slice(1)
                     }
 

--- a/src/main/webui/src/ProposalEditorView/targets/TargetTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetTable.tsx
@@ -154,8 +154,8 @@ function TargetTableRow(props: TargetProps): ReactElement {
         const celestialTarget: CelestialTarget = data as CelestialTarget;
         //console.log(data);
         if(celestialTarget.sourceCoordinates?.lat?.unit?.value === "degrees")
-            //ra = celestialTarget.sourceCoordinates?.lat?.value+"°";
-            ra = AstroLib.DegToHms(celestialTarget.sourceCoordinates?.lat.value ?? 0,3);
+            //Astrolib DegToHms returns a string with redundant (some may say even erroneous) '+' at the start
+            ra = AstroLib.DegToHms(celestialTarget.sourceCoordinates?.lat.value ?? 0,3).slice(1);
         else
             ra = celestialTarget.sourceCoordinates?.lat?.value + " " +
                 celestialTarget.sourceCoordinates?.lat?.unit?.value;

--- a/src/main/webui/src/ProposalEditorView/targets/TargetTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetTable.tsx
@@ -154,7 +154,7 @@ function TargetTableRow(props: TargetProps): ReactElement {
         const celestialTarget: CelestialTarget = data as CelestialTarget;
         //console.log(data);
         if(celestialTarget.sourceCoordinates?.lat?.unit?.value === "degrees")
-            //Astrolib DegToHms returns a string with redundant (some may say even erroneous) '+' at the start
+            //DJW: Astrolib DegToHms prepend sign issue
             ra = AstroLib.DegToHms(celestialTarget.sourceCoordinates?.lat.value ?? 0,3).slice(1);
         else
             ra = celestialTarget.sourceCoordinates?.lat?.value + " " +

--- a/src/main/webui/src/ProposalEditorView/targets/aladinTypes.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/aladinTypes.tsx
@@ -3,10 +3,12 @@
  *
  * see Aladin-lite documentation https://aladin.cds.unistra.fr/AladinLite/doc/API/
  *
- * @param {(ra: number, dec: number) => void}} gotoRaDec route aladin to
- * location.
+ * @param {(ra: number, dec: number) => void}} gotoRaDec route aladin to location.
  * @param {(data: any) => void} addCatalog adds a catalog to aladin.
  * @param {(data: any) => void} addOverlay adds an overlay to aladin.
+ * @param {(x: number, y: number) => number []} pix2world returns the ra,dec coordinates corresponding to the x,y pixel location
+ * @param {(objectName: string) => void} adjustFovForObject where possible automatically changes the FOV for best view of the given object
+ * @param {() => number []} getRaDec returns ra,dec of the Aladin Lite view center
  */
 export type AladinType = {
     gotoRaDec: (ra: number, dec: number) => void;
@@ -14,6 +16,7 @@ export type AladinType = {
     addOverlay: (data: any) => void;
     pix2world: (x: number, y: number) => number [];
     adjustFovForObject: (objectName: string) => void;
+    getRaDec: () => number [];
 }
 /**
  * defines the configuration types for aladin; default values in comments

--- a/src/main/webui/src/ProposalEditorView/targets/simbadSearch.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/simbadSearch.tsx
@@ -241,7 +241,7 @@ function SimbadSearch(props: {form: UseFormReturnType<NewTargetFormValues>}) {
                                         //convert ra,dec to sexagesimal and update input fields
                                         props.form.setFieldValue('ra', AstroLib.DegToHms(arr[1]));
                                         props.form.setFieldValue('dec', AstroLib.DegToDms(arr[2]));
-                                        //props.form.setFieldValue('sexagesimal', arr[3])
+                                        props.form.setFieldValue('sexagesimal', arr[3])
 
                                         //arr[4] is the oid number - not needed by user
 

--- a/src/main/webui/src/ProposalEditorView/targets/simbadSearch.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/simbadSearch.tsx
@@ -238,7 +238,7 @@ function SimbadSearch(props: {form: UseFormReturnType<NewTargetFormValues>}) {
                                     } else {
                                         //set the form fields
                                         props.form.setFieldValue('targetName', displayName(arr[0]))
-                                        ///remove the redundant '+' prepended on string from Astrolib
+                                        //DJW: Astrolib DegToHms prepend sign issue
                                         props.form.setFieldValue('ra', AstroLib.DegToHms(arr[1]).slice(1));
                                         props.form.setFieldValue('dec', AstroLib.DegToDms(arr[2]));
                                         props.form.setFieldValue('sexagesimal', arr[3])

--- a/src/main/webui/src/ProposalEditorView/targets/simbadSearch.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/simbadSearch.tsx
@@ -22,7 +22,7 @@ import {
     SIMBAD_URL_TAP_SERVICE
 } from "../../constants.tsx";
 import {UseFormReturnType} from "@mantine/form";
-import {Aladin, newTargetData} from "./New.tsx";
+import {Aladin, NewTargetFormValues} from "./New.tsx";
 import {IconSearch} from "@tabler/icons-react";
 import {modals} from "@mantine/modals";
 import { AstroLib } from "@tsastro/astrolib";
@@ -58,7 +58,7 @@ have children that do have coordinates.
 
 
 export
-function SimbadSearch(props: {form: UseFormReturnType<newTargetData>}) {
+function SimbadSearch(props: {form: UseFormReturnType<NewTargetFormValues>}) {
     const combobox = useCombobox({
         onDropdownClose: () => combobox.resetSelectedOption(),
     });
@@ -237,10 +237,10 @@ function SimbadSearch(props: {form: UseFormReturnType<newTargetData>}) {
                                         })
                                     } else {
                                         //set the form fields
-                                        props.form.setFieldValue('TargetName', displayName(arr[0]))
+                                        props.form.setFieldValue('targetName', displayName(arr[0]))
                                         //convert ra,dec to sexagesimal and update input fields
-                                        props.form.setFieldValue('RA', AstroLib.DegToHms(arr[1]));
-                                        props.form.setFieldValue('Dec', AstroLib.DegToDms(arr[2]));
+                                        props.form.setFieldValue('ra', AstroLib.DegToHms(arr[1]));
+                                        props.form.setFieldValue('dec', AstroLib.DegToDms(arr[2]));
                                         //props.form.setFieldValue('sexagesimal', arr[3])
 
                                         //arr[4] is the oid number - not needed by user

--- a/src/main/webui/src/ProposalEditorView/targets/simbadSearch.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/simbadSearch.tsx
@@ -238,8 +238,8 @@ function SimbadSearch(props: {form: UseFormReturnType<NewTargetFormValues>}) {
                                     } else {
                                         //set the form fields
                                         props.form.setFieldValue('targetName', displayName(arr[0]))
-                                        //convert ra,dec to sexagesimal and update input fields
-                                        props.form.setFieldValue('ra', AstroLib.DegToHms(arr[1]));
+                                        ///remove the redundant '+' prepended on string from Astrolib
+                                        props.form.setFieldValue('ra', AstroLib.DegToHms(arr[1]).slice(1));
                                         props.form.setFieldValue('dec', AstroLib.DegToDms(arr[2]));
                                         props.form.setFieldValue('sexagesimal', arr[3])
 

--- a/src/main/webui/src/ProposalEditorView/targets/simbadSearchHelp.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/simbadSearchHelp.tsx
@@ -63,14 +63,13 @@ function SimbadSearchHelp() : ReactElement {
 
                     <Text size={"sm"}>
                         The Aladin viewer is connected to the form in that you may set the RA and Dec values in the form
-                        either by left click dragging the viewer to, or by left clicking on, the desired location. A
-                        double left click will also move the reticule to the location under the pointer.
-                        The field-of-view may be modified by the mouse wheel, or the scroll operation appropriate
-                        to your touchpad
-                    </Text>
-                    <Text size={"sm"}>
-                        If you click on the viewer accidentally you may reset the the Ra and Dec
-                        values and the reticule by re-selecting your desired target from the search results list.
+                        by double-clicking on the desired location in the viewer.
+                        The view will also be centred on that location i.e., the reticle will now be over the
+                        double-clicked target.
+                        If you have not yet given the target a name, one will be randomly generated for you, but
+                        we suggest you change it to something more discernible.
+                        The field-of-view may be modified by the mouse wheel, or the scroll operation appropriate to
+                        your touchpad.
                     </Text>
                     <Text size={"sm"}>
                         Notice that you may input Ra and Dec values manually and the viewer will move to that
@@ -93,6 +92,13 @@ function SimbadSearchHelp() : ReactElement {
                         with the corresponding data when an object is selected. Also, the Aladin Sky Atlas viewer
                         will move to the selected target. Feel free to ignore our search facility and input values
                         into the <Text span inherit c={highlightColour}>Target Form </Text> manually.
+                        Ra and Dec values may be entered as either sexagesimal format
+                        i.e., Ra: <Text span inherit fs={"italic"}>hh mm ss.fff</Text>,
+                        Dec: <Text span inherit fs={"italic"}>[+|-]dd mm ss.fff</Text>,
+                        or as decimal degrees Ra: <Text span inherit fs={"italic"}>ddd.fff</Text>,
+                        Dec: <Text span inherit fs={"italic"}>[+|-]dd.fff</Text>. Notice that the precision of the fraction
+                        input, <Text span inherit fs={"italic"}>f</Text>, is unlimited but the actual number stored in
+                        the database is limited to 17 significant figures (slight overkill), units of degrees.
                     </Text>
                     <Text size={"sm"} c={highlightColour}>
                         Notice that all targets, regardless of input method, are assumed to have an ICRS coordinate
@@ -132,7 +138,7 @@ function SimbadSearchHelp() : ReactElement {
                         the search box. Some SIMBAD targets, for example Stellar Streams and Gravitation Wave Events,
                         may not have definitive celestial coordinates for legitimate reasons. In this case a pop-up
                         will open asking if you would like to got to the corresponding SIMBAD site for that object.
-                        These objects may have children that will have definitive celestial coordinates.
+                        These objects may have children that may have definitive celestial coordinates.
                     </Text>
                 </Stack>
                 </ScrollArea>

--- a/src/main/webui/src/ProposalEditorView/targets/simbadSearchHelp.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/simbadSearchHelp.tsx
@@ -3,12 +3,15 @@ import {Anchor, List, ScrollArea, Stack, Tabs, Text} from "@mantine/core";
 import {IconAlien, IconGlobe, IconInfoCircle, IconQuestionMark} from "@tabler/icons-react";
 
 export default
-function SimbadSearchHelp() : ReactElement {
+function SimbadSearchHelp(p: {largeScrollArea: boolean}) : ReactElement {
     const headerColour = "blue"
     const highlightColour = "orange"
 
-    const STACK_PT = 10;
-    const SCROLLAREA_HEIGHT = 120;
+    const stack_pt = 10;
+    const scroll_height_md = 110;
+    const scroll_height_lg = 300;
+
+    const scroll_height = p.largeScrollArea ? scroll_height_lg : scroll_height_md;
 
     return(
         <Tabs allowTabDeactivation variant={"outline"}>
@@ -28,8 +31,12 @@ function SimbadSearchHelp() : ReactElement {
             </Tabs.List>
 
             <Tabs.Panel value={"general"}>
-                <ScrollArea h={SCROLLAREA_HEIGHT} type={"auto"} offsetScrollbars>
-                    <Stack pt={STACK_PT}>
+                <ScrollArea
+                    h={scroll_height}
+                    type={"auto"}
+                    offsetScrollbars
+                >
+                    <Stack pt={stack_pt}>
                         <Text c={headerColour} size={"sm"}>
                             <Text span inherit c={highlightColour}>S</Text>et of
                             <Text span inherit c={highlightColour}> I</Text>dentifications,
@@ -49,8 +56,8 @@ function SimbadSearchHelp() : ReactElement {
             </Tabs.Panel>
 
             <Tabs.Panel value={"aladin"}>
-                <ScrollArea h={SCROLLAREA_HEIGHT} type={"auto"} offsetScrollbars>
-                <Stack pt={STACK_PT}>
+                <ScrollArea h={scroll_height} type={"auto"} offsetScrollbars>
+                <Stack pt={stack_pt}>
                     <Text size={"sm"} c={headerColour}>
                         Aladin Sky Atlas
                     </Text>
@@ -80,8 +87,8 @@ function SimbadSearchHelp() : ReactElement {
                 </ScrollArea>
             </Tabs.Panel>
             <Tabs.Panel value={"searchInstructions"}>
-                <ScrollArea h={SCROLLAREA_HEIGHT} type={"auto"} offsetScrollbars>
-                <Stack pt={STACK_PT}>
+                <ScrollArea h={scroll_height} type={"auto"} offsetScrollbars>
+                <Stack pt={stack_pt}>
                     <Text size={"sm"} c={headerColour}>
                         How to use SIMBAD search
                     </Text>
@@ -145,8 +152,8 @@ function SimbadSearchHelp() : ReactElement {
             </Tabs.Panel>
 
             <Tabs.Panel value={"searchTips"}>
-                <ScrollArea h={SCROLLAREA_HEIGHT} type={"auto"} offsetScrollbars scrollbars={"y"}>
-                <Stack pt={STACK_PT}>
+                <ScrollArea h={scroll_height} type={"auto"} offsetScrollbars scrollbars={"y"}>
+                <Stack pt={stack_pt}>
                     <Text size={"sm"} c={headerColour}>
                         Hints and Tips
                     </Text>


### PR DESCRIPTION
- Moved new target form into a page panel
- adjusted the layout due to more space plus some responsiveness improvements
- more stringent format checking of the Ra and Dec inputs
- range checks added to both Ra and Dec inputs
- form submit button enabled only if all inputs are valid
- double click on the atlas viewer now populates Ra and Dec inputs with the viewer's central location directly

Couple of points about the Astrolib library functions: 

1. If a sexagesimal number contains no fractional part then Astrolib appears to not to understand that this is semantically the same as "ss.0" and does not perform a conversion to decimal degrees (for both RA and Dec). In this case, we can simply check for no decimal place in the sexagesimal string in the Typescript and append the ".0" where necessary before calling the "to-degrees" conversion functions. 
2. The Astrolib function DegToHms seems to erroneously prepended the returned string with a sign. I've worked around this by slicing the returned string from index 1. 
