### PR TITLE
373 make observation fields invisible to user

### DIFF
--- a/src/main/webui/public/contextualHelpMessages.jsx
+++ b/src/main/webui/public/contextualHelpMessages.jsx
@@ -129,12 +129,12 @@ export const contextualHelpMessages = [
 , {
   id: "MaintObs-eng",
   message: " "
-      + " You must select one Target, and one Technical Goal (Performance parameters), followed by both Observation field and type. "
-      + " If your observation type is Calibration, you must choose Calibration intended use."
-      + " Timing windows are optional, but if you select one, you must provide start and end dates and times"
-      + " (choose the date from the calendar and then select a time from the bottom of the calendar)."
-      + " The slider next to the time fields identifies the window as one to be avoided, and you may add a brief note."
-      + " Save your changes with the Save button at bottom right of the timing windows, or cancel and return without saving by clicking the Cancel button."
+      + " Select the 'type' observation, either 'Target' or 'Calibration'. "
+      + " A 'Calibration Observation' requires you pick an intended use e.g., Pointing, Bandpass, etc."
+      + " You must select at least one Target, and one Technical Goal. "
+      + " At least one 'Timing Window' is required. Here you must provide start and end dates-times for the window. "
+      + " Notice that the end date-time must be after the start date-time. "
+      + " The semantics of the avoid flag is to communicate a timing window that must be avoided for this observation. You may also add a brief optional note."
 }
 , {
   id: "ManageDocs-eng",

--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -69,7 +69,6 @@ import CycleObservatoryPanel from "./ProposalManagerView/proposalCycle/observato
 import CycleTACPanel from "./ProposalManagerView/TAC/tacPanel.tsx";
 import CycleTACAddMemberPanel from "./ProposalManagerView/TAC/tacNewMember.tsx"
 import CycleTitlePanel from "./ProposalManagerView/proposalCycle/title.tsx";
-import ObservationFieldsPanel from "./ProposalEditorView/observationFields/ObservationFieldsPanel.tsx";
 import AssignReviewersPanel from "./ProposalManagerView/assignReviewers/AssignReviewersPanel.tsx";
 import ErrorPage from "./errorHandling/error-page.jsx"
 import {PanelFrame} from "./commonPanel/appearance.tsx";
@@ -262,9 +261,11 @@ function App2(): ReactElement {
                         errorElement: <ErrorPage />,
                     },
                     {
+                        /*
                         path: "proposal/:selectedProposalCode/observationFields",
                         element: <ObservationFieldsPanel />,
                         errorElement: <ErrorPage />,
+                         */
                     },
                     {
                         path: "proposal/:selectedProposalCode/observations",

--- a/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/observationFields/ObservationFieldsPanel.tsx
@@ -72,12 +72,7 @@ export default function ObservationFieldsPanel() : ReactElement {
               <Grid.Col span={10}></Grid.Col>
                               <ObservationFieldModal observationField={undefined}
                                                      fieldNames={fieldNames} />
-                              </Grid>
-              {/*}
-           <Group justify={'center'}>
-                <ObservationFieldModal observationField={undefined} />
-            </Group>
-            */}
+            </Grid>
 
         </PanelFrame>
     )

--- a/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
@@ -1,7 +1,7 @@
 import TargetTypeForm from "./targetType.form.tsx";
 import TimingWindowsForm from "./timingWindows.form.tsx";
 import {ObservationProps} from "./observationPanel.tsx";
-import {Fieldset, Grid, Text, Group, Space} from '@mantine/core';
+import {Fieldset, Text, Group, Stack} from '@mantine/core';
 import {
     CalibrationObservation,
     CalibrationTargetIntendedUse, Observation, Target, TargetObservation,
@@ -431,28 +431,23 @@ function ObservationEditGroup(props: ObservationProps): ReactElement {
 
   return (
     <form onSubmit={handleSubmit}>
-        <ContextualHelpButton messageId={"MaintObs"} />
-        <Grid columns={12}>
-            <Grid.Col span={{base: 12}}>
-                <TargetTypeForm form={form} setFieldName={setFieldName}/>
-            </Grid.Col>
-            <Grid.Col span={{base: 12}}>
-                <Fieldset legend={"Timing windows"}>
-                    <Text ta={"center"} size={"xs"} c={"gray.6"}>
-                        Timezone set to UTC
-                    </Text>
-                    <TimingWindowsForm form={form}/>
-                </Fieldset>
-                <Space h={"md"} />
-                <Group justify={"flex-end"}>
-                    <FormSubmitButton form={form} disabled={form.getValues().timingWindows.length === 0}/>
-                    <CancelButton
-                        onClickEvent={handleCancel}
-                        toolTipLabel={"Go back without saving"}
-                    />
-                </Group>
-            </Grid.Col>
-        </Grid>
+        <Stack>
+            <ContextualHelpButton messageId={"MaintObs"} />
+            <TargetTypeForm form={form} setFieldName={setFieldName}/>
+            <Fieldset legend={"Timing windows"}>
+                <Text ta={"center"} size={"xs"} c={"gray.6"}>
+                    Timezone set to UTC
+                </Text>
+                <TimingWindowsForm form={form}/>
+            </Fieldset>
+            <Group justify={"flex-end"}>
+                <FormSubmitButton form={form} disabled={form.getValues().timingWindows.length === 0}/>
+                <CancelButton
+                    onClickEvent={handleCancel}
+                    toolTipLabel={"Go back without saving"}
+                />
+            </Group>
+        </Stack>
     </form>
     )
 }

--- a/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
@@ -25,7 +25,7 @@ import { TimingWindowGui } from './timingWindowGui.tsx';
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
 import {queryKeyProposals} from "../../queryKeyProposals.tsx";
-import {NO_ROW_SELECTED} from "../../constants.tsx";
+import {err_red_str, NO_ROW_SELECTED} from "../../constants.tsx";
 import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx";
 
 /**
@@ -438,6 +438,13 @@ function ObservationEditGroup(props: ObservationProps): ReactElement {
                 <Text ta={"center"} size={"xs"} c={"gray.6"}>
                     Timezone set to UTC
                 </Text>
+                {
+                    form.getValues().timingWindows.length === 0 &&
+                    <Text ta={'center'} c={err_red_str} size={"sm"}>
+                        Please define at least one Timing Window
+                    </Text>
+                }
+
                 <TimingWindowsForm form={form}/>
             </Fieldset>
             <Group justify={"flex-end"}>

--- a/src/main/webui/src/ProposalEditorView/observations/edit.modal.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.modal.tsx
@@ -1,4 +1,4 @@
-import { useDisclosure } from '@mantine/hooks';
+import {useDisclosure, useMediaQuery} from '@mantine/hooks';
 import { Modal } from '@mantine/core';
 import ObservationEditGroup from './edit.group.tsx';
 import { ObservationProps } from './observationPanel.tsx';
@@ -8,6 +8,9 @@ import AddButton from 'src/commonButtons/add.tsx';
 
 export default function ObservationEditModal(
         observationProps: ObservationProps) {
+
+    const smallScreen = useMediaQuery("(max-width: 1350px)");
+
     /**
      * generates the html for a new button.
      * @return {React.ReactElement} the html for the new button.
@@ -44,9 +47,11 @@ export default function ObservationEditModal(
                     opened={opened}
                     onClose={props.closeModal}
                     title={newObservation ?
-                        "New Observation" :
+                        "Create an Observation" :
                         "View/Edit Observation"}
-                    size = "auto" //fullScreen
+                    size ={"75%"}
+                    fullScreen={smallScreen}
+                    closeOnClickOutside={false}
                 >
                     <ObservationEditGroup {...props}/>
                 </Modal>

--- a/src/main/webui/src/ProposalEditorView/observations/observationPanel.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/observationPanel.tsx
@@ -10,20 +10,17 @@ import { ReactElement } from 'react';
 import ObservationEditModal from './edit.modal.tsx';
 import NavigationButton from 'src/commonButtons/navigation.tsx';
 import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx"
-import {IconTarget, IconChartLine, IconGeometry} from '@tabler/icons-react';
+import {IconTarget, IconChartLine} from '@tabler/icons-react';
 import {PanelFrame, PanelHeader} from "../../commonPanel/appearance.tsx";
 
 
 /**
  * the observation props.
- * @param {Observation | undefined} observation the observation object or
- * undefined if not populated
- * @param {number} observationId the observation id - optional
+ * @param {Observation} observation the observation object or undefined if not populated
  * @param {() => void}} closeModal an optional close modal - optional
  */
 export type ObservationProps = {
-    observation: Observation | undefined,
-    selectedTargets: number[] | undefined,
+    observation?: Observation,
     closeModal?: () => void
 }
 
@@ -33,11 +30,7 @@ export type ObservationProps = {
  * @constructor
  */
 function ObservationsPanel(): ReactElement {
-    return (
-        <>
-            <Observations/>
-        </>
-    );
+    return (<Observations/>);
 }
 
 //reminder we are getting lists of 'ObjectIdentifiers' which contain only a
@@ -69,7 +62,8 @@ function Observations() {
             <PanelHeader
                 isLoading={proposal.isLoading}
                 itemName={proposal.data?.title!}
-                panelHeading={"Observations"} />
+                panelHeading={"Observations"}
+            />
         )
     }
 
@@ -87,8 +81,10 @@ function Observations() {
                     {
                         proposal.data?.observations?.map((observation) => {
                             return (
-                                <ObservationRow id={observation._id!}
-                                                key={observation._id!} />
+                                <ObservationRow
+                                    id={observation._id!}
+                                    key={observation._id!}
+                                />
                             )
                         })
                     }
@@ -131,21 +127,6 @@ function Observations() {
         )
     }
 
-    const ObservationFieldButton = () : ReactElement => {
-        return (
-            <NavigationButton
-                p={5}
-                ml={-5}
-                to={"../proposal/" + selectedProposalCode + "/observationFields"}
-                icon={IconGeometry}
-                toolTipLabel={"Go to Observation Fields page"}
-                label={"at least one observation field"}
-            />
-        )
-    }
-
-
-
     // if still loading. present a loading screen.
     if (proposal.isLoading) {
         return (
@@ -159,9 +140,7 @@ function Observations() {
         )
     }
 
-    if (proposal.data?.targets === undefined ||
-        proposal.data?.technicalGoals === undefined ||
-        proposal.data?.fields === undefined) {
+    if (proposal.data?.targets === undefined || proposal.data?.technicalGoals === undefined) {
         return (
             <PanelFrame>
                 <Header/>
@@ -177,12 +156,6 @@ function Observations() {
                             !proposal.data?.technicalGoals &&
                             <List.Item>
                                 <TechnicalGoalButton/>
-                            </List.Item>
-                        }
-                        {
-                            !proposal.data?.fields &&
-                            <List.Item>
-                                <ObservationFieldButton/>
                             </List.Item>
                         }
                     </List>
@@ -203,7 +176,7 @@ function Observations() {
                 <Space h={"xl"}/>
                 <Grid>
                    <Grid.Col span={10}></Grid.Col>
-                    <ObservationEditModal observation={undefined} selectedTargets={undefined}/>
+                    <ObservationEditModal/>
                 </Grid>
             </PanelFrame>
         )

--- a/src/main/webui/src/ProposalEditorView/observations/targetType.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/targetType.form.tsx
@@ -18,7 +18,7 @@ import { ObservationFormValues } from './edit.group.tsx';
 import {
     OPEN_DELAY,
     NO_ROW_SELECTED, TABLE_MIN_WIDTH,
-    TABLE_SCROLL_HEIGHT, err_red_str, err_yellow_str
+    TABLE_SCROLL_HEIGHT, err_red_str, err_yellow_str, err_green_str
 } from 'src/constants.tsx';
 import { TargetTable } from '../targets/TargetTable.tsx';
 import { TechnicalGoalsTable } from '../technicalGoals/technicalGoalTable.tsx';
@@ -136,7 +136,7 @@ export default function TargetTypeForm (p: {
                         p.form.getValues().targetDBIds.length == 0 ?
                             <Text c={err_red_str} span inherit>Please select at least one</Text>
                             :
-                            <Text c={err_yellow_str} span inherit>Multiple selections allowed</Text>
+                            <Text c={err_green_str} span inherit>Multiple selections allowed</Text>
                     }
                 </Text>
                 {
@@ -184,7 +184,7 @@ export default function TargetTypeForm (p: {
                     { p.form.getValues().techGoalId === NO_ROW_SELECTED ?
                         <Text c={err_red_str} span inherit>Please select one</Text>
                         :
-                        <Text c={err_yellow_str} span inherit>Select one only</Text>
+                        <Text c={err_green_str} span inherit>Selected</Text>
                     }
                 </Text>
                 {

--- a/src/main/webui/src/ProposalEditorView/targets/TargetTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetTable.tsx
@@ -3,7 +3,7 @@ import {
     useProposalResourceRemoveTarget,
 } from 'src/generated/proposalToolComponents.ts';
 
-import { Table, Text, useMantineTheme } from '@mantine/core';
+import { Table, Text } from '@mantine/core';
 import { CelestialTarget } from 'src/generated/proposalToolSchemas.ts';
 import {useQueryClient} from "@tanstack/react-query";
 import { ReactElement } from 'react';
@@ -11,7 +11,7 @@ import {modals} from "@mantine/modals";
 import DeleteButton from "src/commonButtons/delete";
 import { TargetProps, TargetTableProps } from './targetProps.tsx';
 import { AstroLib } from "@tsastro/astrolib";
-import {    ERROR_YELLOW,
+import {
     TABLE_HIGH_LIGHT_COLOR
 } from 'src/constants.tsx';
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
@@ -214,12 +214,11 @@ function TargetTableRow(props: TargetProps): ReactElement {
  * @constructor
  */
 export function TargetTable(props: TargetTableProps): ReactElement {
-    const theme = useMantineTheme();
     return (
-        <Table highlightOnHover borderColor={
-                props.selectedTargets?.length === 0 ?
-                    theme.colors.yellow[ERROR_YELLOW]:
-                    undefined}>
+        <Table
+            highlightOnHover
+            borderColor={props.borderColor}
+        >
             {TargetTableHeader(props)}
             <Table.Tbody>
                 {props.isLoading ? (

--- a/src/main/webui/src/ProposalEditorView/targets/targetProps.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/targetProps.tsx
@@ -7,7 +7,6 @@ import {
  * @param {number} proposalCode the id for the proposal this target is linked to.
  * @param {number} dbid the database id for this target.
  * @param {boolean} showButtons boolean saying if this row can show its buttons.
- * @param {string} key forced upon us.
  * @param {number []} boundTargets the target ids bound to observations.
  * @param {number | undefined}[] selectedTargets the row(s) to be highlighted in
  * selected mode. If undefined, the view is selected mode is turned off.
@@ -18,10 +17,9 @@ export type TargetProps = {
     proposalCode: number,
     dbid: number,
     showButtons: boolean,
-    key: string,
     boundTargets: (number | undefined)[] | undefined,
     selectedTargets: (number)[] | undefined,
-    setSelectedTargetFunction?:  (value: number) => void,
+    setSelectedTargetFunction?:  (value: number) => void
 }
 
 /**
@@ -46,5 +44,5 @@ export type TargetTableProps = {
     showButtons: boolean,
     boundTargets: (number | undefined)[] | undefined,
     selectedTargets: (number)[] | undefined,
-    setSelectedTargetFunction?: (value: number) => void,
+    setSelectedTargetFunction?: (value: number) => void
 }

--- a/src/main/webui/src/ProposalEditorView/targets/targetProps.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/targetProps.tsx
@@ -1,6 +1,7 @@
 import {
     ProposalResourceGetTargetsResponse
 } from 'src/generated/proposalToolComponents.ts';
+import {DefaultMantineColor} from "@mantine/core";
 
 /**
  * target prop.
@@ -45,4 +46,5 @@ export type TargetTableProps = {
     boundTargets: (number | undefined)[] | undefined,
     selectedTargets: (number)[] | undefined,
     setSelectedTargetFunction?: (value: number) => void
+    borderColor?: DefaultMantineColor
 }

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/technicalGoalTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/technicalGoalTable.tsx
@@ -1,11 +1,10 @@
 import { useParams } from 'react-router-dom';
 import {
-    Badge,
+    Badge, DefaultMantineColor,
     Group, Loader,
     Space,
     Table,
-    Text,
-    useMantineTheme
+    Text
 } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import TechnicalGoalEditModal from './edit.modal.tsx';
@@ -31,7 +30,6 @@ import {
 import { notSet } from './edit.group.tsx';
 import { ReactElement } from 'react';
 import {
-    ERROR_YELLOW,
     NO_ROW_SELECTED,
     TABLE_HIGH_LIGHT_COLOR
 } from 'src/constants.tsx';
@@ -77,6 +75,7 @@ export type TechnicalGoalsTableProps = {
     showButtons: boolean,
     selectedTechnicalGoal: number | undefined,
     setSelectedTechnicalGoal?: (value: number) => void,
+    borderColor?: DefaultMantineColor
 }
 
 /**
@@ -402,12 +401,10 @@ function technicalGoalsHeader(props: TechnicalGoalsTableProps) : ReactElement {
  * @constructor
  */
 export function TechnicalGoalsTable(props: TechnicalGoalsTableProps): ReactElement {
-    const theme = useMantineTheme();
     return (
         <Table
             highlightOnHover
-            borderColor={props.selectedTechnicalGoal === NO_ROW_SELECTED ?
-                theme.colors.yellow[ERROR_YELLOW]: undefined}
+            borderColor={props.borderColor}
         >
             {technicalGoalsHeader(props)}
             <Table.Tbody>

--- a/src/main/webui/src/ProposalList.tsx
+++ b/src/main/webui/src/ProposalList.tsx
@@ -2,7 +2,7 @@ import {ReactElement, useState} from "react";
 import {Accordion, NavLink, useMantineColorScheme, useMantineTheme} from "@mantine/core";
 import {
     IconChartLine,
-    IconFileCheck, IconFiles, IconGeometry,
+    IconFileCheck, IconFiles,
     IconLetterT,
     IconLicense, IconSend,
     IconTarget, IconTelescope,
@@ -105,14 +105,19 @@ export function ProposalList(props:{proposalTitle: string, investigatorName:stri
                              active={"Technical Goals" + proposal.code === active}
                              onClick={()=>setActive("Technical Goals" + proposal.code)}
                     />
-                    <NavLink to={"proposal/" + proposal.code + "/observationFields"}
-                             component={Link}
-                             leftSection={<IconGeometry/>}
-                             label="Observation Fields"
-                             key="Observation Fields"
-                             active={"Observation Fields" + proposal.code === active}
-                             onClick={()=>setActive("Observation Fields" + proposal.code)}
-                    />
+                    {
+                        /*
+                        <NavLink to={"proposal/" + proposal.code + "/observationFields"}
+                                 component={Link}
+                                 leftSection={<IconGeometry/>}
+                                 label="Observation Fields"
+                                 key="Observation Fields"
+                                 active={"Observation Fields" + proposal.code === active}
+                                 onClick={()=>setActive("Observation Fields" + proposal.code)}
+                        />
+                         */
+                    }
+
                     <NavLink to={"proposal/" + proposal.code + "/observations"}
                              component={Link}
                              leftSection={<IconTelescope/>}

--- a/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
+++ b/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
@@ -47,6 +47,7 @@ export interface FormSubmitButtonInterfaceProps {
     variant?: ButtonVariant
     notValidToolTipLabel?: string
     notDirtyToolTipLabel?: string
+    disabled?: boolean
 }
 
 /**

--- a/src/main/webui/src/commonButtons/save.tsx
+++ b/src/main/webui/src/commonButtons/save.tsx
@@ -39,7 +39,7 @@ function FormSubmitButton(props: FormSubmitButtonInterfaceProps): ReactElement {
                 color={"indigo.5"}
                 variant={props.variant ?? "subtle"}
                 type="submit"
-                disabled={!props.form.isValid() || !props.form.isDirty()}
+                disabled={!props.form.isValid() || !props.form.isDirty() || props.disabled}
             >
                 {label}
             </Button>

--- a/src/main/webui/src/constants.tsx
+++ b/src/main/webui/src/constants.tsx
@@ -73,6 +73,7 @@ export const ERROR_YELLOW = 6;
 
 export const err_yellow_str = "yellow.6"
 export const err_red_str = "red.6"
+export const err_green_str = "green.6"
 
 /* this constant is the expected name of the file which contains the json data.
  */

--- a/src/main/webui/src/constants.tsx
+++ b/src/main/webui/src/constants.tsx
@@ -71,6 +71,9 @@ export const JQUERY_SRC_URL = 'https://code.jquery.com/jquery-1.12.1.min.js';
 /* the color selection of yellow needed for errors */
 export const ERROR_YELLOW = 6;
 
+export const err_yellow_str = "yellow.6"
+export const err_red_str = "red.6"
+
 /* this constant is the expected name of the file which contains the json data.
  */
 export const JSON_FILE_NAME = 'proposal.json';


### PR DESCRIPTION
User no longer has to create a TargetField, these are automatically created when an Observation is created. The TargetField is given the name of the (primary) target of the observation. 

Notice that I have made some visual changes to the Observation form with the intention to make it more user friendly. Also, a user must now provide at least one Timing Window to save an Observation. 