### PR TITLE
371 restrict management page

### DIFF
--- a/src/main/webui/package-lock.json
+++ b/src/main/webui/package-lock.json
@@ -27,6 +27,7 @@
         "jspdf": "^2.5.1",
         "jszip": "^3.8.0",
         "jszip-utils": "0.1.0",
+        "jwt-decode": "^4.0.0",
         "namor": "^3.0.1",
         "prismjs": "^1.29.0",
         "react": "^18.3.1",
@@ -6518,6 +6519,15 @@
       "resolved": "https://registry.npmjs.org/jszip-utils/-/jszip-utils-0.1.0.tgz",
       "integrity": "sha512-tBNe0o3HAf8vo0BrOYnLPnXNo5A3KsRMnkBFYjh20Y3GPYGfgyoclEMgvVchx0nnL+mherPi74yLPIusHUQpZg==",
       "license": "(MIT OR GPL-3.0)"
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/katex": {
       "version": "0.16.11",

--- a/src/main/webui/package.json
+++ b/src/main/webui/package.json
@@ -18,11 +18,13 @@
     "@types/prismjs": "^1.26.4",
     "@types/react-latex": "^2.0.3",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "aladin-lite": "^3.6.1-beta",
     "dayjs": "^1.11.9",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",
     "jszip": "^3.8.0",
     "jszip-utils": "0.1.0",
+    "jwt-decode": "^4.0.0",
     "namor": "^3.0.1",
     "prismjs": "^1.29.0",
     "react": "^18.3.1",
@@ -34,8 +36,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "react-table": "^7.8.0",
     "semantic-ui-react": "^2.1.4",
-    "web-vitals": "^2.1.0",
-    "aladin-lite": "^3.6.1-beta"
+    "web-vitals": "^2.1.0"
   },
   "devDependencies": {
     "@openapi-codegen/cli": "^2.0.2",

--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -78,6 +78,7 @@ import EditorLandingPage from "./ProposalEditorView/landingPage/editorLandingPag
 import TitleSummaryKind from "./ProposalEditorView/proposal/TitleSummaryKind.tsx";
 import {notifyError} from "./commonPanel/notifications.tsx";
 import JSZip from "jszip";
+import {HaveAnyRole, HaveRole} from "./auth/Roles.tsx";
 
 /**
  * defines the user context type.
@@ -410,7 +411,7 @@ function App2(): ReactElement {
                                     <img src={"/pst/gui/polaris4.png"}
                                          alt="Polaris"
                                          width={60}/>
-                                    <Tooltip
+                                    {HaveRole(["tac_admin","tac_member"]) &&  (<Tooltip
                                         label={"go to proposal management view"}
                                         openDelay={OPEN_DELAY}
                                     >
@@ -421,7 +422,7 @@ function App2(): ReactElement {
                                         >
                                             <IconUniverse />
                                         </ActionIcon>
-                                    </Tooltip>
+                                    </Tooltip>)}
                                     <DatabaseSearchButton
                                         toolTipLabel={
                                             "Locate proposals by " +

--- a/src/main/webui/src/auth/Roles.tsx
+++ b/src/main/webui/src/auth/Roles.tsx
@@ -2,9 +2,9 @@ import {jwtDecode} from "jwt-decode";
 import {useToken} from "../App2.tsx";
 
 /**
- * Check current users roles for any one given
- * @param roles An array of strings of roles
- * @return boolean returns true if current user has ANY of the roles in the array
+ * Check current user's roles for any one in array
+ * @param roles A string array of roles
+ * @return boolean returns true if current user has ANY of the roles passed
  */
 export function HaveRole (roles: String[]) {
     const token = useToken();

--- a/src/main/webui/src/auth/Roles.tsx
+++ b/src/main/webui/src/auth/Roles.tsx
@@ -1,0 +1,27 @@
+import {jwtDecode} from "jwt-decode";
+import {useToken} from "../App2.tsx";
+
+/**
+ * Check current users roles for any one given
+ * @param roles An array of strings of roles
+ * @return boolean returns true if current user has ANY of the roles in the array
+ */
+export function HaveRole (roles: String[]) {
+    const token = useToken();
+    let roleFound: boolean = false;
+
+    if(token) {
+        const decodedToken = jwtDecode(token);
+
+        // @ts-ignore
+        if(decodedToken && decodedToken.realm_access && decodedToken.realm_access.roles) {
+            roles.forEach(roleName => {
+                // @ts-ignore
+                if (decodedToken.realm_access.roles.includes(roleName)) roleFound = true;
+            })
+        }
+
+    }
+    return roleFound;
+
+}


### PR DESCRIPTION
Created a new function to test for a user's role(s) and used this to hide the management button from anyone who isn't a tac_admin or tac_member.

This does not stop a user pasting the management url into a browser to visit the page.  Further restrictions should be added in future.