### PR TITLE
378 remove badge re spectral line lookup plus tidy up

### DIFF
--- a/src/main/webui/public/contextualHelpMessages.jsx
+++ b/src/main/webui/public/contextualHelpMessages.jsx
@@ -97,14 +97,20 @@ export const contextualHelpMessages = [
        + " You can make a copy of any existing technical goal by clicking its Copy button."
 }
 , {
-  id: "MaintTechGoal-eng",
-  message: " "
-       + " You must provide values and units for the following performance parameters"
-       + " - Angular resolution, Largest scale, Sensitivity, and Spectral point."
-       + " Spectral windows are optional, but if you select one you must enter values and units for"
-       + " Start, End, and Resolution, as well as polarization."
-       + " Save your changes with the Save button at bottom right of the spectral windows, or cancel and return without saving by clicking the Cancel button."
-}
+    id: "MaintTechGoal-eng",
+    message: " "
+        + " You must provide values and units for the following performance parameters:"
+        + " - angular resolution; largest scale; sensitivity; and spectral point."
+        + " Spectral windows are optional."
+  }
+, {
+    id: "MaintTechGoalSpectralWindows-eng",
+    message: " "
+        + " Spectral windows are optional. Click 'Add' to bring up a window form. "
+        + " You must enter values and units for the start, end, and resolution, as well as polarization, of the window."
+        + " You may add multiple windows. "
+        + " If 'Save' is enabled this will also capture the Performance Parameter input values you entered."
+  }
 , {
   id: "MaintObsFieldList-eng",
   message: " "

--- a/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
@@ -18,7 +18,7 @@ import {
 } from 'src/generated/proposalToolComponents.ts';
 import {FormSubmitButton} from 'src/commonButtons/save.tsx';
 import CancelButton from "src/commonButtons/cancel.tsx";
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import {ReactElement, SyntheticEvent, useState} from 'react';
 import { TimingWindowGui } from './timingWindowGui.tsx';
@@ -417,11 +417,9 @@ function ObservationEditGroup(props: ObservationProps): ReactElement {
             }
     });
 
-  const navigate = useNavigate();
-
   function handleCancel(event: SyntheticEvent) {
       event.preventDefault();
-      navigate("../",{relative:"path"})
+      props.closeModal!();
   }
 
   /*

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/edit.group.tsx
@@ -1,6 +1,6 @@
 import PerformanceParametersSection from "./performance.form.tsx";
 import SpectralWindowsSection from "./spectrum.form.tsx";
-import {Grid, Stack} from "@mantine/core";
+import {Group, Space, Tabs} from "@mantine/core";
 import {TechnicalGoalProps} from "./technicalGoalsPanel.tsx";
 import { ReactElement, SyntheticEvent } from 'react';
 import {useParams, useNavigate} from "react-router-dom";
@@ -53,13 +53,6 @@ export interface TechnicalGoalValues {
 export default function TechnicalGoalEditGroup(
     props: TechnicalGoalProps ): ReactElement {
 
-    // integers specifying the proportional number of columns for the performance parameter
-    // section and the spectral window section
-    const TOTAL_COLUMNS = 10;
-    const PERFORMANCE_COLUMNS = 4;
-    const SPECTRUM_COLUMNS = TOTAL_COLUMNS - PERFORMANCE_COLUMNS
-    // setup default values (proposal code, query system,
-    // and the technical goal)
     const {selectedProposalCode} = useParams();
     const queryClient = useQueryClient();
     const newTechnicalGoal = !props.technicalGoal;
@@ -303,26 +296,37 @@ export default function TechnicalGoalEditGroup(
 
     return (
         <form onSubmit={handleSubmit}>
-            <ContextualHelpButton messageId="MaintTechGoal" />
-        <Stack>
-            <Grid columns={TOTAL_COLUMNS}>
-                <Grid.Col span={{base: TOTAL_COLUMNS, md: PERFORMANCE_COLUMNS}}>
-                    <PerformanceParametersSection form={form}/>
-                </Grid.Col>
-                <Grid.Col span={{base: TOTAL_COLUMNS, md: SPECTRUM_COLUMNS}}>
+            <Tabs defaultValue={"performanceParameters"}>
+                <Tabs.List>
+                    <Tabs.Tab value={"performanceParameters"}>
+                        Performance Parameters
+                    </Tabs.Tab>
+                    <Tabs.Tab value={"SpectralWindows"}>
+                        Spectral Windows
+                    </Tabs.Tab>
+                </Tabs.List>
+
+                <Tabs.Panel value={"performanceParameters"}>
+                    <Space h={"sm"}/>
+                    <ContextualHelpButton messageId="MaintTechGoal" />
+                    <PerformanceParametersSection form={form} />
+                </Tabs.Panel>
+                <Tabs.Panel value={"SpectralWindows"}>
+                    <Space h={"sm"}/>
+                    <ContextualHelpButton messageId="MaintTechGoalSpectralWindows" />
                     <SpectralWindowsSection form={form}/>
-                    <p> </p>
-                    <Grid>
-                    <Grid.Col span={8}></Grid.Col>
-                       <FormSubmitButton form={form} />
-                       <CancelButton
-                          onClickEvent={handleCancel}
-                           toolTipLabel={"Go back without saving"}/>
-                     </Grid>
-                     <p> </p>
-                </Grid.Col>
-                </Grid>
-        </Stack>
+                </Tabs.Panel>
+            </Tabs>
+
+            <Space h={"xl"} />
+
+            <Group justify={"flex-end"}>
+                <FormSubmitButton form={form} />
+                <CancelButton
+                    onClickEvent={handleCancel}
+                    toolTipLabel={"Go back without saving"}
+                />
+            </Group>
         </form>
     )
 }

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/edit.group.tsx
@@ -2,8 +2,8 @@ import PerformanceParametersSection from "./performance.form.tsx";
 import SpectralWindowsSection from "./spectrum.form.tsx";
 import {Group, Space, Tabs} from "@mantine/core";
 import {TechnicalGoalProps} from "./technicalGoalsPanel.tsx";
-import { ReactElement, SyntheticEvent } from 'react';
-import {useParams, useNavigate} from "react-router-dom";
+import {ReactElement, SyntheticEvent} from 'react';
+import {useParams} from "react-router-dom";
 import {useQueryClient} from "@tanstack/react-query";
 import {
     convertToScienceSpectralWindow,
@@ -29,7 +29,6 @@ import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import {ContextualHelpButton} from "src/commonButtons/contextualHelp.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
 
-export const notSpecified = "not specified";
 export const notSet = "not set";
 
 /**
@@ -193,10 +192,9 @@ export default function TechnicalGoalEditGroup(
         }
     )
 
-    const navigate = useNavigate();
     function handleCancel(event: SyntheticEvent) {
         event.preventDefault();
-        navigate("../",{relative:"path"})
+        props.closeModal!();
     }
 
     const handleSubmit = form.onSubmit((values) => {
@@ -228,12 +226,6 @@ export default function TechnicalGoalEditGroup(
             })
 
         } else {
-
-            /*
-                Perhaps we should split performance parameters and spectral windows into separate forms?
-                Have a tabs in the modal for both. It may reduce the code complexity here somewhat.
-             */
-
 
             //editing an existing technical goal
             if (form.isDirty('performanceParameters')) {
@@ -267,7 +259,10 @@ export default function TechnicalGoalEditGroup(
                             },
                             body: convertToScienceSpectralWindow(sw)
                         }, {
-                            onSuccess: () => queryClient.invalidateQueries(),
+                            onSuccess: () => {
+                                queryClient.invalidateQueries().then();
+                                notifySuccess("Edit successful", "A Spectral Window has been added");
+                            },
                             onError: (error) =>
                                 notifyError("Failed to add new spectral window", getErrorMessage(error))
                         })
@@ -283,7 +278,10 @@ export default function TechnicalGoalEditGroup(
                             },
                             body: convertToScienceSpectralWindow(sw)
                         }, {
-                            onSuccess: () => queryClient.invalidateQueries(),
+                            onSuccess: () => {
+                                queryClient.invalidateQueries().then();
+                                notifySuccess("Edit successful", "Spectral Windows updated");
+                            },
                             onError: (error) =>
                                 notifyError("Failed to update spectral window", getErrorMessage(error))
                         })
@@ -301,7 +299,7 @@ export default function TechnicalGoalEditGroup(
                     <Tabs.Tab value={"performanceParameters"}>
                         Performance Parameters
                     </Tabs.Tab>
-                    <Tabs.Tab value={"SpectralWindows"}>
+                    <Tabs.Tab value={"spectralWindows"}>
                         Spectral Windows
                     </Tabs.Tab>
                 </Tabs.List>
@@ -311,7 +309,7 @@ export default function TechnicalGoalEditGroup(
                     <ContextualHelpButton messageId="MaintTechGoal" />
                     <PerformanceParametersSection form={form} />
                 </Tabs.Panel>
-                <Tabs.Panel value={"SpectralWindows"}>
+                <Tabs.Panel value={"spectralWindows"}>
                     <Space h={"sm"}/>
                     <ContextualHelpButton messageId="MaintTechGoalSpectralWindows" />
                     <SpectralWindowsSection form={form}/>

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/edit.modal.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/edit.modal.tsx
@@ -1,4 +1,4 @@
-import {useDisclosure} from "@mantine/hooks";
+import {useDisclosure, useMediaQuery} from "@mantine/hooks";
 import {Modal} from "@mantine/core";
 import ViewEditButton from "src/commonButtons/viewEdit.tsx";
 import {ReactElement} from "react";
@@ -15,6 +15,8 @@ import TechnicalGoalEditGroup from "./edit.group.tsx";
  */
 export default function TechnicalGoalEditModal(
         technicalGoalProps: TechnicalGoalProps): ReactElement {
+
+    const smallScreen = useMediaQuery("(max-width: 1350px)");
     /**
      * creates an add button under the new label.
      *
@@ -55,11 +57,9 @@ export default function TechnicalGoalEditModal(
                 title={newTechnicalGoal ?
                     "New Technical Goal" :
                     "View/Edit Technical Goal No." + technicalGoalProps.technicalGoal?._id}
-                fullScreen
-                //size="auto"
-                //width={100}
-                //height="auto"
-                //centered
+                size ={"65%"}
+                fullScreen={smallScreen}
+                closeOnClickOutside={false}
             >
                 <TechnicalGoalEditGroup {...props} />
             </Modal>

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/performance.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/performance.form.tsx
@@ -1,4 +1,4 @@
-import {Fieldset, Group, Stack, Tooltip} from "@mantine/core";
+import {Box, Group, Stack, Tooltip} from "@mantine/core";
 import {UseFormReturnType} from "@mantine/form";
 import {angularUnits, frequencyUnits, dynamicRangeUnits, fluxUnits} from "src/physicalUnits/PhysicalUnits.tsx";
 import { NumberInputPlusUnit} from "src/commonInputs/NumberInputPlusUnit.tsx";
@@ -21,59 +21,63 @@ export default function PerformanceParametersSection(
     const PerformanceDetails = () => {
         return (
             <Tooltip.Group openDelay={OPEN_DELAY} closeDelay={CLOSE_DELAY}>
-                <Stack>
-                    <Group grow>
-                        <NumberInputPlusUnit
-                            form={form}
-                            label={"Angular resolution"}
-                            toolTip={"desired angular resolution"}
-                            valueRoot={'performanceParameters.angularResolution'}
-                            units={angularUnits}
-                        />
-                    </Group>
-                    <Group grow>
-                        <NumberInputPlusUnit
-                            form={form}
-                            label={'Largest scale'}
-                            toolTip={"desired largest scale"}
-                            valueRoot={'performanceParameters.largestScale'}
-                            units={angularUnits}
-                        />
-                    </Group>
-                    <Group grow>
-                        <NumberInputPlusUnit
-                            form={form}
-                            label={"Sensitivity"}
-                            toolTip={"desired sensitivity"}
-                            valueRoot={'performanceParameters.sensitivity'}
-                            units={fluxUnits} />
-                    </Group>
-                    <Group grow>
-                        <NumberInputPlusUnit
-                            form={form}
-                            label={"Dynamic range"}
-                            toolTip={"desired dynamic range"}
-                            valueRoot={'performanceParameters.dynamicRange'}
-                            units={dynamicRangeUnits}
-                        />
-                    </Group>
-                    <Group grow>
-                        <NumberInputPlusUnit
-                            form={form}
-                            label={"Spectral point"}
-                            toolTip={"representative spectral frequency"}
-                            valueRoot={'performanceParameters.spectralPoint'}
-                            units={frequencyUnits}
-                        />
-                    </Group>
-                </Stack>
+                <Box mt={10} mx={"10%"} w="85%">
+                    <Stack>
+                        <Group grow>
+                            <NumberInputPlusUnit
+                                form={form}
+                                label={"Angular resolution"}
+                                toolTip={"desired angular resolution"}
+                                valueRoot={'performanceParameters.angularResolution'}
+                                units={angularUnits}
+                            />
+                        </Group>
+                        <Group grow>
+                            <NumberInputPlusUnit
+                                form={form}
+                                label={'Largest scale'}
+                                toolTip={"desired largest scale"}
+                                valueRoot={'performanceParameters.largestScale'}
+                                units={angularUnits}
+                            />
+                        </Group>
+                        <Group grow>
+                            <NumberInputPlusUnit
+                                form={form}
+                                label={"Sensitivity"}
+                                toolTip={"desired sensitivity"}
+                                valueRoot={'performanceParameters.sensitivity'}
+                                units={fluxUnits} />
+                        </Group>
+                        <Group grow>
+                            <NumberInputPlusUnit
+                                form={form}
+                                label={"Dynamic range"}
+                                toolTip={"desired dynamic range"}
+                                valueRoot={'performanceParameters.dynamicRange'}
+                                units={dynamicRangeUnits}
+                            />
+                        </Group>
+                        <Group grow>
+                            <NumberInputPlusUnit
+                                form={form}
+                                label={"Spectral point"}
+                                toolTip={"representative spectral frequency"}
+                                valueRoot={'performanceParameters.spectralPoint'}
+                                units={frequencyUnits}
+                            />
+                        </Group>
+                    </Stack>
+                </Box>
             </Tooltip.Group>
         )
     }
 
     return (
-        <Fieldset legend={"Performance parameters"}>
-            {PerformanceDetails()}
-        </Fieldset>
+        <>
+            {
+                PerformanceDetails()
+            }
+        </>
     )
 }

--- a/src/main/webui/src/ProposalEditorView/technicalGoals/spectrum.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/technicalGoals/spectrum.form.tsx
@@ -1,10 +1,10 @@
 import {
-    Accordion, Badge,
+    Accordion,
     Checkbox,
-    Fieldset, Grid,
+    Grid,
     Group,
     Select, useMantineColorScheme,
-    Text
+    Text, Stack, ScrollArea
 } from "@mantine/core";
 import {TechnicalGoalValues} from "./edit.group.tsx";
 import AddButton from "src/commonButtons/add.tsx";
@@ -134,20 +134,6 @@ export default function SpectralWindowsSection(
         )
     }
 
-    /**
-     * renders the spectral lines.
-     *
-     * @return {ReactElement} the dynamic html for the spectral lines.
-     */
-    const renderSpectralLines = (): ReactElement => {
-        return (
-            <Fieldset legend={"Spectral lines"}>
-                <Badge radius={0} color={"red"}>
-                    WIP: select predetermined spectral lines
-                </Badge>
-            </Fieldset>
-        )
-    }
 
     /**
      * handles the deletion of a timing window.
@@ -206,26 +192,31 @@ export default function SpectralWindowsSection(
                 />
                 <Accordion.Panel>
                     {renderWindowSetup(mapIndex)}
-                    {renderSpectralLines()}
                 </Accordion.Panel>
             </Accordion.Item>
         )
     })
 
+    //height of ScrollArea determined by good-old-fashioned trail-and-error to match height
+    //of the PerformanceParameter tab section
+
     return(
-        <Fieldset legend={"Spectral windows"}>
-            <Accordion defaultValue={"1"} chevronPosition={"left"}>
-                {windowsList}
-            </Accordion>
-            <Group justify={"center"}>
-                <AddButton
-                    toolTipLabel={"add a spectral window"}
-                    onClick={() => form.insertListItem(
-                        'spectralWindows',
-                        {...EMPTY_SPECTRAL_WINDOW, key: randomId()}
-                    )}
-                />
-            </Group>
-        </Fieldset>
+        <ScrollArea h={378}>
+            <Stack>
+                <Accordion defaultValue={"1"} chevronPosition={"left"}>
+                    {windowsList}
+                </Accordion>
+                <Group justify={"center"}>
+                    <AddButton
+                        toolTipLabel={"add a spectral window"}
+                        onClick={() => form.insertListItem(
+                            'spectralWindows',
+                            {...EMPTY_SPECTRAL_WINDOW, key: randomId()}
+                        )}
+                    />
+                </Group>
+            </Stack>
+        </ScrollArea>
+
     )
 }


### PR DESCRIPTION
Removed badge claiming work in progress for spectral line lookup service.

Performance Parameters and Spectral Windows now in their own tabs.

Update contextual help text. 

Notify users on successful edit to spectral windows.

(fixed problem with cancel buttons on modals, navigating "up-one" rather than just closing the modal)