### PR TITLE
Manager View: assign reviewers tidy up

### DIFF
--- a/src/main/webui/src/ProposalManagerView/assignReviewers/AssignReviewersPanel.tsx
+++ b/src/main/webui/src/ProposalManagerView/assignReviewers/AssignReviewersPanel.tsx
@@ -2,7 +2,6 @@ import {ReactElement} from "react";
 import {ManagerPanelHeader, PanelFrame} from "../../commonPanel/appearance.tsx";
 import {useParams} from "react-router-dom";
 import AssignReviewersAccordion from "./assignReviewers.accordion.tsx";
-import {Badge, Card, Group, Text} from "@mantine/core";
 
 
 
@@ -15,24 +14,7 @@ export default function AssignReviewersPanel() : ReactElement {
                 proposalCycleCode={Number(selectedCycleCode)}
                 panelHeading={"Assign Reviewers"}
             />
-
-            <Group justify={"center"}>
-                <Card shadow={"sm"} padding={"xs"} radius={"md"} withBorder w={"60%"} m={"lg"}>
-                    <Card.Section>
-                        <Badge bg={"blue"} c={"yellow"} radius={0}>
-                            Prototype Version: This should be a "TAC Chair" viewable page only
-                        </Badge>
-                    </Card.Section>
-                    <Text c={"pink"} size={"sm"}>
-                        In the release version it is envisaged that this page be available to a user
-                        or users with the "TAC Chair" role only. Other Committee members can self-assign as
-                        a Reviewer to Submitted Proposals of choice elsewhere.
-                    </Text>
-                </Card>
-            </Group>
-
             <AssignReviewersAccordion />
-
         </PanelFrame>
     )
 }

--- a/src/main/webui/src/ProposalManagerView/assignReviewers/assignReviewers.accordion.tsx
+++ b/src/main/webui/src/ProposalManagerView/assignReviewers/assignReviewers.accordion.tsx
@@ -1,5 +1,5 @@
 import {ReactElement} from "react";
-import {Accordion, Badge, Group, Loader, Space, Text} from "@mantine/core";
+import {Accordion, Badge, Container, Group, Loader, Space, Text} from "@mantine/core";
 import {
     useSubmittedProposalResourceGetSubmittedNotYetAllocated,
     useSubmittedProposalResourceGetSubmittedProposal
@@ -91,6 +91,16 @@ export default function AssignReviewersAccordion() : ReactElement {
         notifyError("Failed to load not yet allocated submitted proposals",
             getErrorMessage(notYetAllocated.error))
 
+    }
+
+    if (notYetAllocated.data?.length === 0) {
+        return (
+            <Container mt={"10%"} mx={"20%"} fluid>
+                <Badge size={"lg"} radius={"xs"} color={"green"}>
+                    There are no outstanding submitted proposals to be assigned reviewers
+                </Badge>
+            </Container>
+        )
     }
 
     return (


### PR DESCRIPTION
Removed badge about tac-chair functionality.

Added badge when there are no remaining submitted proposals to assign reviewers.