### PR TITLE
412 download all proposals from a cycle, with investigators removed.

### DIFF
--- a/src/main/webui/src/ProposalManagerView/proposalCycle/downloadProposals.ts
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/downloadProposals.ts
@@ -1,0 +1,106 @@
+import {
+    fetchSupportingDocumentResourceGetSupportingDocuments,
+    SubmittedProposalResourceGetSubmittedProposalsResponse
+} from "../../generated/proposalToolComponents";
+import * as Schemas from "../../generated/proposalToolSchemas";
+import * as JSZip from "jszip";
+import {OverviewPanelInternal} from "../../ProposalEditorView/proposal/Overview";
+import {
+    extractJSON, extractTelescope,
+    generatePdf,
+    populateSupportingDocuments
+} from "../../ProposalEditorView/proposal/downloadProposal";
+import {OVERVIEW_PDF_FILENAME, POLARIS_MODES} from "../../constants";
+import {ObjectIdentifier} from "../../generated/proposalToolSchemas";
+import {notifyError, notifySuccess} from "../../commonPanel/notifications";
+import getErrorMessage from "../../errorHandling/getErrorMessage";
+import {NavigateFunction} from "react-router-dom";
+import {QueryClient} from "@tanstack/react-query";
+export async function downloadProposals(
+        data: SubmittedProposalResourceGetSubmittedProposalsResponse,
+        forceUpdate: () => void,
+        authToken: string,
+        cycleTitle: string,
+        printRef: React.RefObject<HTMLInputElement>,
+        navigate: NavigateFunction,
+        queryClient: QueryClient,
+        polarisMode: POLARIS_MODES):
+        Promise<void> {
+
+    const topZip = new JSZip();
+    const proposalPromises: Promise<void>[] = [];
+
+    data.map(async (proposalIDData: Schemas.ObjectIdentifier) => {
+        const proposalPromise = new Promise<void>(() => {
+            // generate the html which will become the pdf.
+            OverviewPanelInternal({
+                forceUpdate: forceUpdate,
+                selectedProposalCode: proposalIDData.dbid!.toString(),
+                printRef: printRef,
+                showInvestigators: false,
+                expandAccordions: true,
+                authToken: authToken,
+                navigate: navigate,
+                queryClient: queryClient,
+                polarisMode: polarisMode,
+            });
+            const pdfData = generatePdf(printRef.current!);
+            // build the zip object and populate with the corresponding documents.
+            let proposalZip = new JSZip();
+            proposalZip = proposalZip.file(OVERVIEW_PDF_FILENAME, pdfData);
+
+            // extract supporting documents.
+            fetchSupportingDocumentResourceGetSupportingDocuments(
+                {
+                    pathParams: {
+                        proposalCode: proposalIDData.dbid!
+                    }
+                }
+            ).then(async (supportingDocumentData: ObjectIdentifier[]) => {
+                // add supporting documents to the zip.
+                const promises = populateSupportingDocuments(
+                    proposalZip, supportingDocumentData,
+                    proposalIDData.dbid!.toString(),
+                    authToken
+                );
+
+                // get proposal json.
+                promises.push(extractJSON(
+                    authToken, proposalIDData.dbid!.toString(), proposalZip));
+
+                // process optical data.
+                await extractTelescope(
+                    proposalIDData.dbid!.toString(), promises, proposalZip);
+
+                // put all files in the top zip.
+                Promise.all(promises).then(
+                    () => {
+                        const innerZipBuffer = proposalZip.generateAsync(
+                            {type: "blob"});
+                        topZip.file(proposalIDData.name!, innerZipBuffer);
+                    })
+            });
+        });
+        proposalPromises.push(proposalPromise);
+    });
+
+    try {
+        await Promise.all(proposalPromises);
+        // all inner zips should be done here.
+        const zipData = await topZip.generateAsync({type: "blob"});
+
+        // Create a download link for the zip file
+        const link = document.createElement("a");
+        link.href = window.URL.createObjectURL(new Blob([zipData]));
+        link.download = cycleTitle.replace(/\s/g, "").substring(0, 31) + ".zip";
+        link.click();
+        window.URL.revokeObjectURL(link.href); // Clean up the URL object.
+
+        notifySuccess(
+            "Proposal Export Complete", "proposal exported" +
+            " and downloaded")
+    } catch(error: unknown) {
+        notifyError("Proposal Export Failed", getErrorMessage(error));
+        console.error("Error creating or downloading top zip", error);
+    }
+}

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/overview.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/overview.tsx
@@ -1,9 +1,11 @@
-import {ReactElement} from "react";
+import {ReactElement, useContext, useReducer, useRef} from "react";
 import {Divider, Fieldset, Group, Space, Stack, Text} from "@mantine/core";
 import {
+    fetchSubmittedProposalResourceGetSubmittedProposals,
+    SubmittedProposalResourceGetSubmittedProposalsResponse,
     useProposalCyclesResourceGetProposalCycle
 } from "../../generated/proposalToolComponents.ts";
-import {useParams} from "react-router-dom";
+import {useNavigate, useParams} from "react-router-dom";
 import {PanelFrame} from "../../commonPanel/appearance.tsx";
 import AllocationGradesTable from "./allocationGradesTable.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
@@ -11,6 +13,12 @@ import {notifyError} from "../../commonPanel/notifications.tsx";
 import TACMembersTable from "./TACMembersTable.tsx";
 import SubmittedProposalsTable from "./submittedProposalsTable.tsx";
 import AvailableResourcesTable from "./availableResourcesTable.tsx";
+import {ProposalContext, useToken} from "../../App2";
+import {ExportButton} from "../../commonButtons/export";
+import {POLARIS_MODES} from "../../constants";
+import {downloadProposals} from "./downloadProposals";
+import {useProposalToolContext} from "../../generated/proposalToolContext";
+import {useQueryClient} from "@tanstack/react-query";
 
 
 //ASSUMES input string is ISO date-time at GMT+0
@@ -28,10 +36,24 @@ export default function CycleOverviewPanel() : ReactElement {
 
     const {selectedCycleCode} = useParams();
 
+    const {fetcherOptions} = useProposalToolContext();
+
+    const authToken = useToken();
+
+    const navigate = useNavigate();
+
+    const queryClient = useQueryClient();
+
+    const printRef = useRef<HTMLInputElement>(null);
+
+    const polarisMode = useContext(ProposalContext).mode;
+
+    //this work around is used when deleting a proposal
+    const [,forceUpdate] = useReducer(x => x + 1, 0);
+
     const cycleSynopsis = useProposalCyclesResourceGetProposalCycle(
         {pathParams: {cycleCode: Number(selectedCycleCode)}}
     )
-
     if (cycleSynopsis.error) {
         notifyError("Failed to load proposal cycle synopsis",
             "cause " + getErrorMessage(cycleSynopsis.error))
@@ -120,10 +142,52 @@ export default function CycleOverviewPanel() : ReactElement {
         )
     }
 
+    const DownloadAllProposals = (): ReactElement => {
+        return ExportButton(
+            {
+                toolTipLabel: `Export all proposals to a file for download`,
+                disabled: false,
+                onClick: handleDownloadPdf,
+                label: "Export cycle Proposals",
+                variant: "filled",
+                toolTipLabelPosition: "top"
+            });
+    }
 
+    /**
+     * generates the overview pdf and saves it to the users' disk.
+     *
+     * code extracted from: https://www.robinwieruch.de/react-component-to-pdf/
+     * @return {Promise<void>} promise that the pdf will be saved at some point.
+     */
+    async function handleDownloadPdf(): Promise<void> {
+        await fetchSubmittedProposalResourceGetSubmittedProposals(
+            {...fetcherOptions,
+             pathParams: {cycleCode: Number(selectedCycleCode)}}
+        ).then(
+            (data: SubmittedProposalResourceGetSubmittedProposalsResponse) => {
+                if (cycleSynopsis.data?.title != null) {
+                    downloadProposals(
+                        data, forceUpdate, authToken, cycleSynopsis.data?.title,
+                        printRef, navigate, queryClient, polarisMode);
+                }
+            }
+        )
+    }
+
+    /**
+     * generates the html.
+     */
     return (
         <PanelFrame>
             <DisplayTitle />
+            { polarisMode === POLARIS_MODES.OPTICAL &&
+                <>
+                    <Space h={"xl"}/>
+                    <DownloadAllProposals/>
+                    <Space h={"xl"}/>
+                </>
+            }
             <DisplayObservatory />
             <Space h={"xl"}/>
             <DisplayDates />

--- a/src/main/webui/src/generated/proposalToolComponents.ts
+++ b/src/main/webui/src/generated/proposalToolComponents.ts
@@ -7944,6 +7944,7 @@ export type ProposalResourceExportProposalPathParams = {
    * @format int64
    */
   proposalCode: number;
+  investigatorsIncluded: boolean;
 };
 
 export type ProposalResourceExportProposalError =


### PR DESCRIPTION
ties in a request from Dan to be able to download all proposals for a given cycle. The caveat here is that we need to remove investigators as well as a inner zip process. 

part of the issues found is that since download has been made, the tables on the overview page have changed to accordions which by default don't show all the details. So this pr, on top of the actual code to make the nested zip, has had to figure a way to expand those accordions by default when making the pdf. 

This work should likely be pushed to the default export functionality once figured out fully.