### PR TITLE
Move and fix filter cycles by observatory

### DIFF
--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -118,8 +118,6 @@ export const useToken = (): string => {
     return useContext(ProposalContext).getToken();
 };
 
-//export const [selectedObservatory, setSelectedObservatory] = useState<number>(0);
-
 /**
  * generates the html for the main app.
  * @return {ReactElement} dynamic html for the main app.

--- a/src/main/webui/src/ProposalManagerView/proposalCycle.new.form.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle.new.form.tsx
@@ -6,7 +6,7 @@ import {Group, Select, Stack, Text, TextInput} from "@mantine/core";
 import {MAX_CHARS_FOR_INPUTS} from "../constants.tsx";
 import {DatesProvider, DateTimePicker} from "@mantine/dates";
 import {
-    useObservatoryResourceGetObservatory,
+    useObservatoryResourceGetObservatories,
     useProposalCyclesResourceCreateProposalCycle
 } from "../generated/proposalToolComponents.ts";
 import getErrorMessage from "../errorHandling/getErrorMessage.tsx";
@@ -14,25 +14,24 @@ import {notifyError, notifySuccess} from "../commonPanel/notifications.tsx";
 import {useQueryClient} from "@tanstack/react-query";
 
 interface NewCycleFormProps {
-    closeModal?: () => void,
-    selectedObservatory: number
+    closeModal?: () => void
 }
 
-export default function NewCycleForm({closeModal, selectedObservatory}: NewCycleFormProps): ReactElement {
+export default function NewCycleForm({closeModal}: NewCycleFormProps): ReactElement {
 
     interface NewCycleFormType {
         title: string,
         submissionDeadline: Date | null,
         sessionStart: Date | null,
         sessionEnd: Date | null,
-        observatoryId: number
+        observatoryId: number | null
     }
     const queryClient = useQueryClient();
 
     const [observatories, setObservatories]
         = useState<{ value: string, label: string }[]>([]);
 
-    const {data, status, error} = useObservatoryResourceGetObservatory({pathParams:{id: selectedObservatory}});
+    const {data, status, error} = useObservatoryResourceGetObservatories({queryParams: {}});
 
     const createProposalCycleMutation = useProposalCyclesResourceCreateProposalCycle({
         onSuccess: (newCycle) => {
@@ -54,9 +53,10 @@ export default function NewCycleForm({closeModal, selectedObservatory}: NewCycle
         else {
               if(data != undefined)
                   setObservatories(
-                        [{value: String(data._id), label: data.name!}]
+                      data?.map((obs) => (
+                          {value: String(obs.dbid), label: obs.name!}
+                      ))
                 );
-              form.values.observatoryId=selectedObservatory;
         }
     }, [data, status]);
 
@@ -69,7 +69,7 @@ export default function NewCycleForm({closeModal, selectedObservatory}: NewCycle
                 submissionDeadline: null,
                 sessionStart: null,
                 sessionEnd: null,
-                observatoryId: selectedObservatory
+                observatoryId: null
             },
 
             validate: {
@@ -136,7 +136,6 @@ export default function NewCycleForm({closeModal, selectedObservatory}: NewCycle
                         label={"Observatory"}
                         placeholder={"pick one"}
                         data={observatories}
-                        defaultValue={selectedObservatory}
                         {...form.getInputProps('observatoryId')}
                     />
                     <Group justify={"center"}>

--- a/src/main/webui/src/ProposalManagerView/startPage.tsx
+++ b/src/main/webui/src/ProposalManagerView/startPage.tsx
@@ -1,10 +1,10 @@
-import {ReactElement, useState} from "react";
+import {ReactElement} from "react";
 import {
     ActionIcon,
     AppShell,
     Burger,
     Grid,
-    Group, Modal, ScrollArea, Select,
+    Group, Modal, ScrollArea,
     Tooltip, useMantineTheme
 } from "@mantine/core";
 import {
@@ -22,10 +22,6 @@ import CycleList from "./cycleList.tsx";
 import AddButton from "../commonButtons/add.tsx";
 import NewCycleForm from "./proposalCycle.new.form.tsx";
 import {HaveRole} from "../auth/Roles.tsx";
-import {useObservatoryResourceGetObservatories}  from "../generated/proposalToolComponents.ts";
-
-//import {selectedObservatory, setSelectedObservatory} from "../App2.tsx";
-
 
 export default function ProposalManagerStartPage() : ReactElement {
     const navigate = useNavigate();
@@ -33,21 +29,6 @@ export default function ProposalManagerStartPage() : ReactElement {
     const theme = useMantineTheme();
 
     const [modalOpened, {close, open}] = useDisclosure();
-
-    const [selectedObservatory, setSelectedObservatory] = useState<number>(0);
-
-    const obsList = useObservatoryResourceGetObservatories(
-        {queryParams: {}}
-    );
-
-    const observatoryList = obsList.data?.map(obs => {
-        if(obs.dbid) {
-            if (selectedObservatory == 0)
-                setSelectedObservatory(obs.dbid)
-            if (obs.name)
-                return {value: obs.dbid.toString(), label: obs.name};
-        }
-    })
 
     return (
         <AppShell
@@ -88,21 +69,6 @@ export default function ProposalManagerStartPage() : ReactElement {
                                     <IconLicense />
                                 </ActionIcon>
                             </Tooltip>
-                            Observatory
-                            <Select
-                                width={500}
-                                defaultValue={selectedObservatory.toString()}
-                                allowDeselect={false}
-                                comboboxProps={{ width: 200, position: 'bottom-start' }}
-                                aria-label="Select an observatory"
-                                //@ts-ignore
-                                data={observatoryList}
-                                onChange={(_value) => {
-                                        if(_value)
-                                            setSelectedObservatory(+_value)
-                                    }
-                                }
-                            />
                             {HaveRole(["obs_administration"]) &&
                             <AddButton toolTipLabel={"new proposal cycle"}
                                        label={"Create a new Proposal Cycle"}
@@ -115,7 +81,7 @@ export default function ProposalManagerStartPage() : ReactElement {
                                 size={"40%"}
                                 closeOnClickOutside={false}
                             >
-                                <NewCycleForm closeModal={close} selectedObservatory={selectedObservatory}/>
+                                <NewCycleForm closeModal={close} />
                             </Modal>
                         </Group>
                     </Grid.Col>
@@ -140,7 +106,7 @@ export default function ProposalManagerStartPage() : ReactElement {
             </AppShell.Header>
             <AppShell.Navbar>
                 <AppShell.Section component={ScrollArea}>
-                    <CycleList observatory={+selectedObservatory}/>
+                    <CycleList observatory={0}/>
                 </AppShell.Section>
             </AppShell.Navbar>
             <AppShell.Main pr={"sm"}>

--- a/src/main/webui/src/ProposalManagerView/startPage.tsx
+++ b/src/main/webui/src/ProposalManagerView/startPage.tsx
@@ -106,7 +106,7 @@ export default function ProposalManagerStartPage() : ReactElement {
             </AppShell.Header>
             <AppShell.Navbar>
                 <AppShell.Section component={ScrollArea}>
-                    <CycleList observatory={0}/>
+                    <CycleList/>
                 </AppShell.Section>
             </AppShell.Navbar>
             <AppShell.Main pr={"sm"}>


### PR DESCRIPTION
I've changed the TAC management page, mostly just the left hand menu.  I believe it makes more sense this way.

By default it lists all cycles that you are associated with.  These can be filtered to show only those that are still open for submissions, and optionally filtered by observatory.  The observatory filter has been moved to the left hand menu and is only shown when the option is selected, this fixes the initial render issue.