### PR TITLE
419 user management required

### DIFF
--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -41,12 +41,11 @@ import {
     Tooltip, useMantineTheme, useMantineColorScheme, FileButton, Container, Button,
 } from '@mantine/core';
 import {ColourSchemeToggle} from "./ColourSchemeToggle";
-import {IconUniverse} from '@tabler/icons-react';
+import {IconHome, IconUniverse} from '@tabler/icons-react';
 import {useDisclosure} from "@mantine/hooks";
 import AddButton from './commonButtons/add';
-import DatabaseSearchButton from './commonButtons/databaseSearch';
 import {
-    APP_HEADER_HEIGHT, JSON_FILE_NAME,
+    APP_HEADER_HEIGHT, CLOSE_DELAY, JSON_FILE_NAME,
     NAV_BAR_DEFAULT_WIDTH, NAV_BAR_LARGE_WIDTH,
     NAV_BAR_MEDIUM_WIDTH, OPEN_DELAY,
 } from './constants';
@@ -335,7 +334,7 @@ function App2(): ReactElement {
          *
          * @param {React.SyntheticEvent} event the event.
          */
-        function handleSearch(event: SyntheticEvent): void {
+        function handleNavigateHome(event: SyntheticEvent): void {
             event.preventDefault();
             navigate("/");
         }
@@ -425,26 +424,31 @@ function App2(): ReactElement {
                                         <ActionIcon
                                             color={"pink"}
                                             variant={"subtle"}
-                                            onClick={(e: SyntheticEvent)=>{e.preventDefault(); navigate("/manager")}}
+                                            onClick={(e: SyntheticEvent)=>{
+                                                e.preventDefault();
+                                                navigate("/manager")}}
                                         >
                                             <IconUniverse />
                                         </ActionIcon>
                                     </Tooltip>)}
-                                    <DatabaseSearchButton
-                                        toolTipLabel={
-                                            "Locate proposals by " +
-                                            proposalContext.user.fullName + "."}
-                                        label={"Proposals for " + proposalContext.user.fullName}
-                                        onClickEvent={handleSearch}
-                                    />
-
+                                    <Tooltip
+                                        label={"Go to your home page"}
+                                        openDelay={OPEN_DELAY}
+                                        closeDelay={CLOSE_DELAY}
+                                    >
+                                        <Button
+                                            rightSection={<IconHome/>}
+                                            onClick={handleNavigateHome}
+                                            variant={"subtle"}
+                                            color={"green.5"}
+                                        >
+                                            {proposalContext.user.fullName}'s Home Page
+                                        </Button>
+                                    </Tooltip>
                                 </Group>
                             </Grid.Col>
                             <Grid.Col span={1}>
                                 <Group justify={"flex-end"}>
-                                    <Button onClick={() => navigate("admin")}>
-                                        Admin
-                                    </Button>
                                     {ColourSchemeToggle()}
                                     <UserMenu />
                                 </Group>

--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -38,7 +38,7 @@ import {
     ScrollArea,
     Group,
     ActionIcon,
-    Tooltip, useMantineTheme, useMantineColorScheme, FileButton, Container,
+    Tooltip, useMantineTheme, useMantineColorScheme, FileButton, Container, Button,
 } from '@mantine/core';
 import {ColourSchemeToggle} from "./ColourSchemeToggle";
 import {IconUniverse} from '@tabler/icons-react';
@@ -442,6 +442,9 @@ function App2(): ReactElement {
                             </Grid.Col>
                             <Grid.Col span={1}>
                                 <Group justify={"flex-end"}>
+                                    <Button onClick={() => navigate("admin")}>
+                                        Admin
+                                    </Button>
                                     {ColourSchemeToggle()}
                                     <UserMenu />
                                 </Group>

--- a/src/main/webui/src/App2.tsx
+++ b/src/main/webui/src/App2.tsx
@@ -41,15 +41,12 @@ import {
     Tooltip, useMantineTheme, useMantineColorScheme, FileButton, Container,
 } from '@mantine/core';
 import {ColourSchemeToggle} from "./ColourSchemeToggle";
-import {
-    IconLogout, IconUniverse
-} from '@tabler/icons-react';
+import {IconUniverse} from '@tabler/icons-react';
 import {useDisclosure} from "@mantine/hooks";
 import AddButton from './commonButtons/add';
 import DatabaseSearchButton from './commonButtons/databaseSearch';
-//import {ContextualHelpButton} from "./commonButtons/contextualHelp.tsx"
 import {
-    APP_HEADER_HEIGHT, CLOSE_DELAY, ICON_SIZE, JSON_FILE_NAME,
+    APP_HEADER_HEIGHT, JSON_FILE_NAME,
     NAV_BAR_DEFAULT_WIDTH, NAV_BAR_LARGE_WIDTH,
     NAV_BAR_MEDIUM_WIDTH, OPEN_DELAY,
 } from './constants';
@@ -77,6 +74,8 @@ import JSZip from "jszip";
 import {HaveRole} from "./auth/Roles.tsx";
 import AddTargetPanel from "./ProposalEditorView/targets/New.tsx";
 import PassFailPanel from "./ProposalManagerView/passFail/PassFailPanel.tsx";
+import UserMenu from "./userMenu.tsx";
+import UserManagement from "./userManagement.tsx";
 
 /**
  * defines the user context type.
@@ -149,6 +148,11 @@ function App2(): ReactElement {
                 children: [
                     {index: true, element: <PSTManagerStart />},
                     {
+                        path: "user/:userId/management",
+                        element: <UserManagement />,
+                        errorElement: <ErrorPage />
+                    },
+                    {
                         path: "cycle/:selectedCycleCode",
                         element: <CycleOverviewPanel />,
                         errorElement: <ErrorPage />,
@@ -206,6 +210,11 @@ function App2(): ReactElement {
                         path: "admin",
                         element: <AdminPanel />,
                         errorElement: <ErrorPage />,
+                    },
+                    {
+                        path: "user/:userId/management",
+                        element: <UserManagement />,
+                        errorElement: <ErrorPage />
                     },
                     {
                         path: "proposal/new",
@@ -376,7 +385,7 @@ function App2(): ReactElement {
 
         /*
         DJW:
-        I'd like to move the 'AppShell' stuff to its own file, however in doing so the
+        I'd like to move the 'AppShell' stuff to its own file, however, in doing so the
         Accordion used to navigate the proposal in the left-hand navbar seems not to
         remember state; the accordion item does not get highlighted and, more fundamentally,
         the accordion collapses, and I can't figure out why.
@@ -434,18 +443,7 @@ function App2(): ReactElement {
                             <Grid.Col span={1}>
                                 <Group justify={"flex-end"}>
                                     {ColourSchemeToggle()}
-                                    <Tooltip label={"logout"}
-                                             openDelay={OPEN_DELAY}
-                                             closeDelay={CLOSE_DELAY}
-                                    >
-                                        <ActionIcon color={"orange.8"}
-                                                    variant={"subtle"}
-                                                    component={"a"}
-                                                    href={"/pst/gui/logout"}
-                                        >
-                                            <IconLogout size={ICON_SIZE}/>
-                                        </ActionIcon>
-                                    </Tooltip>
+                                    <UserMenu />
                                 </Group>
                             </Grid.Col>
                         </Grid>

--- a/src/main/webui/src/ColourSchemeToggle.tsx
+++ b/src/main/webui/src/ColourSchemeToggle.tsx
@@ -6,7 +6,7 @@ export function ColourSchemeToggle() {
     const { colorScheme, toggleColorScheme } = useMantineColorScheme();
     return (
         <Tooltip
-            label={colorScheme === 'dark' ? 'light mode' : 'dark mode'}
+            label={colorScheme === 'dark' ? 'enable light mode' : 'enable dark mode'}
             openDelay={OPEN_DELAY}
             closeDelay={CLOSE_DELAY}
         >

--- a/src/main/webui/src/ColourSchemeToggle.tsx
+++ b/src/main/webui/src/ColourSchemeToggle.tsx
@@ -1,28 +1,22 @@
-import {useMantineColorScheme, Switch, useMantineTheme} from '@mantine/core';
+import {useMantineColorScheme, ActionIcon, Tooltip} from '@mantine/core';
 import {IconSun, IconMoonStars} from '@tabler/icons-react';
-import { STROKE } from './constants';
+import {CLOSE_DELAY, OPEN_DELAY} from './constants';
 
 export function ColourSchemeToggle() {
     const { colorScheme, toggleColorScheme } = useMantineColorScheme();
-    // the colour gray used by the tools.
-    const theme = useMantineTheme();
-    const GRAY = theme.colors.gray[6];
-
     return (
-        <>
-            <Switch
-                checked={colorScheme === 'dark'}
-                onChange={() => toggleColorScheme()}
-                size="md"
-                onLabel={<IconSun
-                    color={theme.white}
-                    size="1.25em"
-                    stroke={STROKE} />}
-                offLabel={<IconMoonStars
-                    color={GRAY}
-                    size="1.25em"
-                    stroke={STROKE}/>}
-            />
-        </>
+        <Tooltip
+            label={colorScheme === 'dark' ? 'light mode' : 'dark mode'}
+            openDelay={OPEN_DELAY}
+            closeDelay={CLOSE_DELAY}
+        >
+            <ActionIcon
+                variant={"subtle"}
+                onClick={toggleColorScheme}
+            >
+                {colorScheme === 'dark' ? <IconSun /> : <IconMoonStars/>}
+            </ActionIcon>
+
+        </Tooltip>
     );
 }

--- a/src/main/webui/src/ProposalEditorView/targets/TargetTable.tsx
+++ b/src/main/webui/src/ProposalEditorView/targets/TargetTable.tsx
@@ -153,19 +153,19 @@ function TargetTableRow(props: TargetProps): ReactElement {
         //console.log(JSON.stringify(data, null, 2));
         const celestialTarget: CelestialTarget = data as CelestialTarget;
         //console.log(data);
-        if(celestialTarget.sourceCoordinates?.lat?.unit?.value === "degrees")
-            //DJW: Astrolib DegToHms prepend sign issue
-            ra = AstroLib.DegToHms(celestialTarget.sourceCoordinates?.lat.value ?? 0,3).slice(1);
-        else
-            ra = celestialTarget.sourceCoordinates?.lat?.value + " " +
-                celestialTarget.sourceCoordinates?.lat?.unit?.value;
-
         if(celestialTarget.sourceCoordinates?.lon?.unit?.value === "degrees")
-            //dec = celestialTarget.sourceCoordinates?.lon?.value+"°";
-            dec =AstroLib.DegToDms( celestialTarget.sourceCoordinates?.lon.value ??0,3);
+            //DJW: Astrolib DegToHms prepend sign issue
+            ra = AstroLib.DegToHms(celestialTarget.sourceCoordinates?.lon?.value ?? 0,3).slice(1);
         else
-            dec = celestialTarget.sourceCoordinates?.lon?.value + " " +
+            ra = celestialTarget.sourceCoordinates?.lon?.value + " " +
                 celestialTarget.sourceCoordinates?.lon?.unit?.value;
+
+        if(celestialTarget.sourceCoordinates?.lat?.unit?.value === "degrees")
+            //dec = celestialTarget.sourceCoordinates?.lon?.value+"°";
+            dec =AstroLib.DegToDms( celestialTarget.sourceCoordinates?.lat?.value ??0,3);
+        else
+            dec = celestialTarget.sourceCoordinates?.lat?.value + " " +
+                celestialTarget.sourceCoordinates?.lat?.unit?.value;
 
         if(celestialTarget.sourceCoordinates?.coordSys?.["@type"] ===
             "coords:SpaceSys") {

--- a/src/main/webui/src/ProposalManagerView/startPage.tsx
+++ b/src/main/webui/src/ProposalManagerView/startPage.tsx
@@ -8,13 +8,13 @@ import {
     Tooltip, useMantineTheme
 } from "@mantine/core";
 import {
-    APP_HEADER_HEIGHT, CLOSE_DELAY, ICON_SIZE,
+    APP_HEADER_HEIGHT,
     NAV_BAR_DEFAULT_WIDTH,
     NAV_BAR_LARGE_WIDTH,
     NAV_BAR_MEDIUM_WIDTH,
     OPEN_DELAY
 } from "../constants.tsx";
-import {IconLicense, IconLogout} from "@tabler/icons-react";
+import {IconLicense} from "@tabler/icons-react";
 import {Outlet, useNavigate} from "react-router-dom";
 import {ColourSchemeToggle} from "../ColourSchemeToggle.tsx";
 import {useDisclosure} from "@mantine/hooks";
@@ -23,6 +23,7 @@ import AddButton from "../commonButtons/add.tsx";
 import NewCycleForm from "./proposalCycle.new.form.tsx";
 import {HaveRole} from "../auth/Roles.tsx";
 import {useObservatoryResourceGetObservatories}  from "../generated/proposalToolComponents.ts";
+import UserMenu from "../userMenu.tsx";
 
 //import {selectedObservatory, setSelectedObservatory} from "../App2.tsx";
 
@@ -121,19 +122,8 @@ export default function ProposalManagerStartPage() : ReactElement {
                     </Grid.Col>
                     <Grid.Col span={1}>
                         <Group justify={"flex-end"}>
+                            <UserMenu />
                             {ColourSchemeToggle()}
-                            <Tooltip label={"logout"}
-                                     openDelay={OPEN_DELAY}
-                                     closeDelay={CLOSE_DELAY}
-                            >
-                                <ActionIcon color={"orange.8"}
-                                            variant={"subtle"}
-                                            component={"a"}
-                                            href={"/pst/gui/logout"}
-                                >
-                                    <IconLogout size={ICON_SIZE}/>
-                                </ActionIcon>
-                            </Tooltip>
                         </Group>
                     </Grid.Col>
                 </Grid>

--- a/src/main/webui/src/ProposalManagerView/startPage.tsx
+++ b/src/main/webui/src/ProposalManagerView/startPage.tsx
@@ -22,11 +22,7 @@ import CycleList from "./cycleList.tsx";
 import AddButton from "../commonButtons/add.tsx";
 import NewCycleForm from "./proposalCycle.new.form.tsx";
 import {HaveRole} from "../auth/Roles.tsx";
-import {useObservatoryResourceGetObservatories}  from "../generated/proposalToolComponents.ts";
 import UserMenu from "../userMenu.tsx";
-
-//import {selectedObservatory, setSelectedObservatory} from "../App2.tsx";
-
 
 export default function ProposalManagerStartPage() : ReactElement {
     const navigate = useNavigate();

--- a/src/main/webui/src/admin/adminPanel.tsx
+++ b/src/main/webui/src/admin/adminPanel.tsx
@@ -1,28 +1,33 @@
 import {ReactElement} from "react";
-import {ActionIcon, Box, Group, Table, Text, Tooltip} from "@mantine/core";
-import {CLOSE_DELAY, ICON_SIZE, JSON_SPACES, OPEN_DELAY} from "../constants.tsx";
+import {ActionIcon, Group, Loader, Table, Text, Tooltip} from "@mantine/core";
+import {CLOSE_DELAY, ICON_SIZE, OPEN_DELAY} from "../constants.tsx";
 import {IconKey} from "@tabler/icons-react";
 import {
     useSubjectMapResourceSubjectMapList
 } from "../generated/proposalToolComponents.ts";
 import {SubjectMap} from "../generated/proposalToolSchemas.ts";
 import {SubjectMapsTableRow, SubjectMapsTableHeader} from './subjectMapsTable.tsx';
+import AlertErrorMessage from "../errorHandling/alertErrorMessage.tsx";
+import getErrorMessage from "../errorHandling/getErrorMessage.tsx";
 
 function AdminPanel(): ReactElement {
 
-    const {
-        data: subjectMaps,
-        error: subjectMapsError,
-        isLoading: subjectMapsIsLoading
-    } = useSubjectMapResourceSubjectMapList({});
+    const subjectMap  = useSubjectMapResourceSubjectMapList({});
 
-    if (subjectMapsError) {
+    if (subjectMap.isError) {
         return (
-            <Box>
-                <pre>{JSON.stringify(subjectMapsError, null, JSON_SPACES)}</pre>
-            </Box>
+            <AlertErrorMessage
+                title={"Failed to fetch subject map list"}
+                error={getErrorMessage(subjectMap.error)}
+            />
         )
     }
+
+
+    if (subjectMap.isLoading) {
+        return (<Loader/>)
+    }
+
 
     /**
      * function to return the ReactElement for a Table displaying the People stored in
@@ -35,7 +40,7 @@ function AdminPanel(): ReactElement {
                 <SubjectMapsTableHeader />
                 <Table.Tbody>
                     {
-                        subjectMaps?.map((subjectMap : SubjectMap) => {
+                        subjectMap.data?.map((subjectMap : SubjectMap) => {
                             return (
                                 <SubjectMapsTableRow key={subjectMap.uid} {...subjectMap}/>
                             )
@@ -77,16 +82,11 @@ function AdminPanel(): ReactElement {
         )
     }
 
+
     return(
         <>
             <DisplayKeycloakAdminConsoleButton />
-
-            {
-                subjectMapsIsLoading ? "Loading ..." :
-                    <SubjectMapsTable />
-            }
-
-
+            <SubjectMapsTable />
         </>
     )
 }

--- a/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
+++ b/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
@@ -30,6 +30,7 @@ export interface BasicButtonInterfaceProps {
 /**
  * form submit button interface props. Used by FormSubmit button.
  *
+ * @param {UseFormReturnType<any>} form the form that is being "submitted"
  * @param {string} toolTipLabel the label shown when hovered.
  * @param {FloatingPosition} toolTipLabelPosition one of 'left', 'right', 'top', 'bottom', +
  * '-start' and '-end' variants - defaults to 'top'

--- a/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
+++ b/src/main/webui/src/commonButtons/buttonInterfaceProps.tsx
@@ -48,6 +48,7 @@ export interface FormSubmitButtonInterfaceProps {
     notValidToolTipLabel?: string
     notDirtyToolTipLabel?: string
     disabled?: boolean
+    mt?: string
 }
 
 /**

--- a/src/main/webui/src/commonButtons/save.tsx
+++ b/src/main/webui/src/commonButtons/save.tsx
@@ -40,6 +40,7 @@ function FormSubmitButton(props: FormSubmitButtonInterfaceProps): ReactElement {
                 variant={props.variant ?? "subtle"}
                 type="submit"
                 disabled={!props.form.isValid() || !props.form.isDirty() || props.disabled}
+                mt={props.mt ?? ""}
             >
                 {label}
             </Button>

--- a/src/main/webui/src/commonButtons/undo.tsx
+++ b/src/main/webui/src/commonButtons/undo.tsx
@@ -1,0 +1,23 @@
+import {Button, ButtonProps} from "@mantine/core";
+import {IconArrowBack} from "@tabler/icons-react";
+import {ICON_SIZE} from "../constants.tsx";
+import {UseFormReturnType} from "@mantine/form";
+
+export interface UndoButtonProps extends ButtonProps {
+    form: UseFormReturnType<any>
+}
+
+export default
+function UndoButton(props: UndoButtonProps) {
+    return (
+        <Button
+            rightSection={<IconArrowBack size={ICON_SIZE}/>}
+            disabled={!props.form.isDirty()}
+            onClick={() => props.form.reset()}
+            mt={props.mt}
+            color={"red"}
+        >
+            Undo
+        </Button>
+    )
+}

--- a/src/main/webui/src/generated/proposalToolComponents.ts
+++ b/src/main/webui/src/generated/proposalToolComponents.ts
@@ -13112,6 +13112,361 @@ export const useSubjectMapResourceSubjectMap = <TData = Schemas.SubjectMap,>(
   });
 };
 
+export type SubjectMapResourceChangeEmailAddressPathParams = {
+  /**
+   * @format int64
+   */
+  personId: number;
+};
+
+export type SubjectMapResourceChangeEmailAddressError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type SubjectMapResourceChangeEmailAddressVariables = {
+  pathParams: SubjectMapResourceChangeEmailAddressPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchSubjectMapResourceChangeEmailAddress = (
+  variables: SubjectMapResourceChangeEmailAddressVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    SubjectMapResourceChangeEmailAddressError,
+    undefined,
+    {},
+    {},
+    SubjectMapResourceChangeEmailAddressPathParams
+  >({
+    url: "/pst/api/subjectMap/{personId}/email",
+    method: "put",
+    ...variables,
+    signal,
+  });
+
+export const useSubjectMapResourceChangeEmailAddress = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      SubjectMapResourceChangeEmailAddressError,
+      SubjectMapResourceChangeEmailAddressVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    undefined,
+    SubjectMapResourceChangeEmailAddressError,
+    SubjectMapResourceChangeEmailAddressVariables
+  >({
+    mutationFn: (variables: SubjectMapResourceChangeEmailAddressVariables) =>
+      fetchSubjectMapResourceChangeEmailAddress({
+        ...fetcherOptions,
+        ...variables,
+      }),
+    ...options,
+  });
+};
+
+export type SubjectMapResourceChangeFirstNamePathParams = {
+  /**
+   * @format int64
+   */
+  personId: number;
+};
+
+export type SubjectMapResourceChangeFirstNameError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type SubjectMapResourceChangeFirstNameVariables = {
+  pathParams: SubjectMapResourceChangeFirstNamePathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchSubjectMapResourceChangeFirstName = (
+  variables: SubjectMapResourceChangeFirstNameVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    SubjectMapResourceChangeFirstNameError,
+    undefined,
+    {},
+    {},
+    SubjectMapResourceChangeFirstNamePathParams
+  >({
+    url: "/pst/api/subjectMap/{personId}/firstName",
+    method: "put",
+    ...variables,
+    signal,
+  });
+
+export const useSubjectMapResourceChangeFirstName = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      SubjectMapResourceChangeFirstNameError,
+      SubjectMapResourceChangeFirstNameVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    undefined,
+    SubjectMapResourceChangeFirstNameError,
+    SubjectMapResourceChangeFirstNameVariables
+  >({
+    mutationFn: (variables: SubjectMapResourceChangeFirstNameVariables) =>
+      fetchSubjectMapResourceChangeFirstName({
+        ...fetcherOptions,
+        ...variables,
+      }),
+    ...options,
+  });
+};
+
+export type SubjectMapResourceChangeLastNamePathParams = {
+  /**
+   * @format int64
+   */
+  personId: number;
+};
+
+export type SubjectMapResourceChangeLastNameError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type SubjectMapResourceChangeLastNameVariables = {
+  pathParams: SubjectMapResourceChangeLastNamePathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchSubjectMapResourceChangeLastName = (
+  variables: SubjectMapResourceChangeLastNameVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    SubjectMapResourceChangeLastNameError,
+    undefined,
+    {},
+    {},
+    SubjectMapResourceChangeLastNamePathParams
+  >({
+    url: "/pst/api/subjectMap/{personId}/lastName",
+    method: "put",
+    ...variables,
+    signal,
+  });
+
+export const useSubjectMapResourceChangeLastName = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      SubjectMapResourceChangeLastNameError,
+      SubjectMapResourceChangeLastNameVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    undefined,
+    SubjectMapResourceChangeLastNameError,
+    SubjectMapResourceChangeLastNameVariables
+  >({
+    mutationFn: (variables: SubjectMapResourceChangeLastNameVariables) =>
+      fetchSubjectMapResourceChangeLastName({
+        ...fetcherOptions,
+        ...variables,
+      }),
+    ...options,
+  });
+};
+
+export type SubjectMapResourceResetPasswordPathParams = {
+  /**
+   * @format int64
+   */
+  personId: number;
+};
+
+export type SubjectMapResourceResetPasswordError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type SubjectMapResourceResetPasswordVariables = {
+  pathParams: SubjectMapResourceResetPasswordPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchSubjectMapResourceResetPassword = (
+  variables: SubjectMapResourceResetPasswordVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    SubjectMapResourceResetPasswordError,
+    undefined,
+    {},
+    {},
+    SubjectMapResourceResetPasswordPathParams
+  >({
+    url: "/pst/api/subjectMap/{personId}/password",
+    method: "put",
+    ...variables,
+    signal,
+  });
+
+export const useSubjectMapResourceResetPassword = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      SubjectMapResourceResetPasswordError,
+      SubjectMapResourceResetPasswordVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    undefined,
+    SubjectMapResourceResetPasswordError,
+    SubjectMapResourceResetPasswordVariables
+  >({
+    mutationFn: (variables: SubjectMapResourceResetPasswordVariables) =>
+      fetchSubjectMapResourceResetPassword({ ...fetcherOptions, ...variables }),
+    ...options,
+  });
+};
+
+export type SubjectMapResourceGetSubjectMapUidPathParams = {
+  /**
+   * @format int64
+   */
+  personId: number;
+};
+
+export type SubjectMapResourceGetSubjectMapUidError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type SubjectMapResourceGetSubjectMapUidVariables = {
+  pathParams: SubjectMapResourceGetSubjectMapUidPathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchSubjectMapResourceGetSubjectMapUid = (
+  variables: SubjectMapResourceGetSubjectMapUidVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    SubjectMapResourceGetSubjectMapUidError,
+    undefined,
+    {},
+    {},
+    SubjectMapResourceGetSubjectMapUidPathParams
+  >({
+    url: "/pst/api/subjectMap/{personId}/uid",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export const useSubjectMapResourceGetSubjectMapUid = <TData = undefined,>(
+  variables: SubjectMapResourceGetSubjectMapUidVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      undefined,
+      SubjectMapResourceGetSubjectMapUidError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { fetcherOptions, queryOptions, queryKeyFn } =
+    useProposalToolContext(options);
+  return reactQuery.useQuery<
+    undefined,
+    SubjectMapResourceGetSubjectMapUidError,
+    TData
+  >({
+    queryKey: queryKeyFn({
+      path: "/pst/api/subjectMap/{personId}/uid",
+      operationId: "subjectMapResourceGetSubjectMapUid",
+      variables,
+    }),
+    queryFn: ({ signal }) =>
+      fetchSubjectMapResourceGetSubjectMapUid(
+        { ...fetcherOptions, ...variables },
+        signal,
+      ),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export type SubjectMapResourceGetKeycloakUsernamePathParams = {
+  /**
+   * @format int64
+   */
+  personId: number;
+};
+
+export type SubjectMapResourceGetKeycloakUsernameError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type SubjectMapResourceGetKeycloakUsernameVariables = {
+  pathParams: SubjectMapResourceGetKeycloakUsernamePathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchSubjectMapResourceGetKeycloakUsername = (
+  variables: SubjectMapResourceGetKeycloakUsernameVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    SubjectMapResourceGetKeycloakUsernameError,
+    undefined,
+    {},
+    {},
+    SubjectMapResourceGetKeycloakUsernamePathParams
+  >({
+    url: "/pst/api/subjectMap/{personId}/username",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export const useSubjectMapResourceGetKeycloakUsername = <TData = undefined,>(
+  variables: SubjectMapResourceGetKeycloakUsernameVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      undefined,
+      SubjectMapResourceGetKeycloakUsernameError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { fetcherOptions, queryOptions, queryKeyFn } =
+    useProposalToolContext(options);
+  return reactQuery.useQuery<
+    undefined,
+    SubjectMapResourceGetKeycloakUsernameError,
+    TData
+  >({
+    queryKey: queryKeyFn({
+      path: "/pst/api/subjectMap/{personId}/username",
+      operationId: "subjectMapResourceGetKeycloakUsername",
+      variables,
+    }),
+    queryFn: ({ signal }) =>
+      fetchSubjectMapResourceGetKeycloakUsername(
+        { ...fetcherOptions, ...variables },
+        signal,
+      ),
+    ...options,
+    ...queryOptions,
+  });
+};
+
 export type QueryOperation =
   | {
       path: "/pst/api/admin/roles";
@@ -13537,4 +13892,14 @@ export type QueryOperation =
       path: "/pst/api/subjectMap/{id}";
       operationId: "subjectMapResourceSubjectMap";
       variables: SubjectMapResourceSubjectMapVariables;
+    }
+  | {
+      path: "/pst/api/subjectMap/{personId}/uid";
+      operationId: "subjectMapResourceGetSubjectMapUid";
+      variables: SubjectMapResourceGetSubjectMapUidVariables;
+    }
+  | {
+      path: "/pst/api/subjectMap/{personId}/username";
+      operationId: "subjectMapResourceGetKeycloakUsername";
+      variables: SubjectMapResourceGetKeycloakUsernameVariables;
     };

--- a/src/main/webui/src/generated/proposalToolComponents.ts
+++ b/src/main/webui/src/generated/proposalToolComponents.ts
@@ -3277,6 +3277,64 @@ export const usePersonResourceUpdateFullName = (
   });
 };
 
+export type PersonResourceUpdateHomeInstitutePathParams = {
+  /**
+   * @format int64
+   */
+  id: number;
+};
+
+export type PersonResourceUpdateHomeInstituteError =
+  Fetcher.ErrorWrapper<undefined>;
+
+export type PersonResourceUpdateHomeInstituteVariables = {
+  body?: Schemas.Organization;
+  pathParams: PersonResourceUpdateHomeInstitutePathParams;
+} & ProposalToolContext["fetcherOptions"];
+
+export const fetchPersonResourceUpdateHomeInstitute = (
+  variables: PersonResourceUpdateHomeInstituteVariables,
+  signal?: AbortSignal,
+) =>
+  proposalToolFetch<
+    undefined,
+    PersonResourceUpdateHomeInstituteError,
+    Schemas.Organization,
+    {},
+    {},
+    PersonResourceUpdateHomeInstitutePathParams
+  >({
+    url: "/pst/api/people/{id}/homeInstitute",
+    method: "put",
+    ...variables,
+    signal,
+  });
+
+export const usePersonResourceUpdateHomeInstitute = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      PersonResourceUpdateHomeInstituteError,
+      PersonResourceUpdateHomeInstituteVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useProposalToolContext();
+  return reactQuery.useMutation<
+    undefined,
+    PersonResourceUpdateHomeInstituteError,
+    PersonResourceUpdateHomeInstituteVariables
+  >({
+    mutationFn: (variables: PersonResourceUpdateHomeInstituteVariables) =>
+      fetchPersonResourceUpdateHomeInstitute({
+        ...fetcherOptions,
+        ...variables,
+      }),
+    ...options,
+  });
+};
+
 export type PersonResourceUpdateOrcidIdPathParams = {
   /**
    * @format int64

--- a/src/main/webui/src/generated/proposalToolComponents.ts
+++ b/src/main/webui/src/generated/proposalToolComponents.ts
@@ -13402,71 +13402,6 @@ export const useSubjectMapResourceGetSubjectMapUid = <TData = undefined,>(
   });
 };
 
-export type SubjectMapResourceGetKeycloakUsernamePathParams = {
-  /**
-   * @format int64
-   */
-  personId: number;
-};
-
-export type SubjectMapResourceGetKeycloakUsernameError =
-  Fetcher.ErrorWrapper<undefined>;
-
-export type SubjectMapResourceGetKeycloakUsernameVariables = {
-  pathParams: SubjectMapResourceGetKeycloakUsernamePathParams;
-} & ProposalToolContext["fetcherOptions"];
-
-export const fetchSubjectMapResourceGetKeycloakUsername = (
-  variables: SubjectMapResourceGetKeycloakUsernameVariables,
-  signal?: AbortSignal,
-) =>
-  proposalToolFetch<
-    undefined,
-    SubjectMapResourceGetKeycloakUsernameError,
-    undefined,
-    {},
-    {},
-    SubjectMapResourceGetKeycloakUsernamePathParams
-  >({
-    url: "/pst/api/subjectMap/{personId}/username",
-    method: "get",
-    ...variables,
-    signal,
-  });
-
-export const useSubjectMapResourceGetKeycloakUsername = <TData = undefined,>(
-  variables: SubjectMapResourceGetKeycloakUsernameVariables,
-  options?: Omit<
-    reactQuery.UseQueryOptions<
-      undefined,
-      SubjectMapResourceGetKeycloakUsernameError,
-      TData
-    >,
-    "queryKey" | "queryFn" | "initialData"
-  >,
-) => {
-  const { fetcherOptions, queryOptions, queryKeyFn } =
-    useProposalToolContext(options);
-  return reactQuery.useQuery<
-    undefined,
-    SubjectMapResourceGetKeycloakUsernameError,
-    TData
-  >({
-    queryKey: queryKeyFn({
-      path: "/pst/api/subjectMap/{personId}/username",
-      operationId: "subjectMapResourceGetKeycloakUsername",
-      variables,
-    }),
-    queryFn: ({ signal }) =>
-      fetchSubjectMapResourceGetKeycloakUsername(
-        { ...fetcherOptions, ...variables },
-        signal,
-      ),
-    ...options,
-    ...queryOptions,
-  });
-};
-
 export type QueryOperation =
   | {
       path: "/pst/api/admin/roles";
@@ -13897,9 +13832,4 @@ export type QueryOperation =
       path: "/pst/api/subjectMap/{personId}/uid";
       operationId: "subjectMapResourceGetSubjectMapUid";
       variables: SubjectMapResourceGetSubjectMapUidVariables;
-    }
-  | {
-      path: "/pst/api/subjectMap/{personId}/username";
-      operationId: "subjectMapResourceGetKeycloakUsername";
-      variables: SubjectMapResourceGetKeycloakUsernameVariables;
     };

--- a/src/main/webui/src/userManagement.tsx
+++ b/src/main/webui/src/userManagement.tsx
@@ -1,13 +1,261 @@
-import {ReactElement} from "react";
-import {Container, Text} from "@mantine/core";
+import {ReactElement, useContext, useEffect, useState} from "react";
+import {ProposalContext} from "./App2.tsx";
+import {
+    useOrganizationResourceGetOrganization,
+    useOrganizationResourceGetOrganizations,
+    usePersonResourceUpdateEMail,
+    usePersonResourceUpdateFullName,
+    usePersonResourceUpdateHomeInstitute,
+    usePersonResourceUpdateOrcidId
+} from "./generated/proposalToolComponents.ts";
+import {PanelFrame, PanelHeader} from "./commonPanel/appearance.tsx";
+import {Fieldset, Grid, Group, Loader, Select, Space, Stack, Text, TextInput} from "@mantine/core";
+import {useForm} from "@mantine/form";
+import {useQueryClient} from "@tanstack/react-query";
+import {notifyError, notifySuccess} from "./commonPanel/notifications.tsx";
+import getErrorMessage from "./errorHandling/getErrorMessage.tsx";
+import {FormSubmitButton} from "./commonButtons/save.tsx";
+import AlertErrorMessage from "./errorHandling/alertErrorMessage.tsx";
+
+function DisplayOrganisationDetails ({organisationId} : {organisationId: number}) : ReactElement {
+
+    const organisation = useOrganizationResourceGetOrganization({
+        pathParams: {id: organisationId}
+    })
+
+    if (organisation.isLoading) {
+        return (<Loader/>)
+    }
+
+    if (organisation.isError) {
+        return (
+            <AlertErrorMessage
+                title={"Failed to load organisation"}
+                error={getErrorMessage(organisation.error)}
+            />
+        )
+    }
+
+    return (
+        <Fieldset legend={"Institute Details"}>
+            <Text size={"xl"} fw={700}>
+                {organisation.data?.name}
+            </Text>
+            <Space h={"md"}/>
+            <Stack gap={"xs"}>
+                <Text>
+                    <b>Address:</b> {organisation.data?.address}
+                </Text>
+                <Text>
+                    <b>IVO id:</b> {organisation.data?.ivoid?.value}
+                </Text>
+                <Text>
+                    <b>Wiki id:</b> {organisation.data?.wikiId?.value}
+                </Text>
+            </Stack>
+        </Fieldset>
+    )
+}
 
 export default
 function UserManagement() : ReactElement {
+
+    const {user} = useContext(ProposalContext);
+    const queryClient = useQueryClient();
+    const [selectOrganisation, setSelectOrganisation] = useState<{value: string, label: string}[]>([]);
+
+    const organisations = useOrganizationResourceGetOrganizations({})
+
+    const fullNameMutate = usePersonResourceUpdateFullName();
+    const emailMutate = usePersonResourceUpdateEMail();
+    const orchidIdMutate = usePersonResourceUpdateOrcidId();
+    const homeInstituteMutate = usePersonResourceUpdateHomeInstitute();
+
+    const fullNameForm = useForm<{fullName: string}>({
+        initialValues: {fullName: user.fullName!}
+    })
+
+    const emailForm = useForm<{email: string}>({
+        initialValues: {email: user.eMail!}
+    })
+
+    const orchidIdForm = useForm<{orchidId: string}>({
+        initialValues: {orchidId: user.orcidId?.value ??  ""}
+    })
+
+    const homeInstituteForm = useForm<{homeInstitute: string}>({
+        initialValues: {homeInstitute: String(user.homeInstitute?._id!)}
+    })
+
+    useEffect(() => {
+        if (organisations.status === 'success') {
+            setSelectOrganisation(
+                organisations.data.map((org) => (
+                    {value: String(org.dbid), label: org.name!}
+                ))
+            )
+        }
+    }, [organisations]);
+
+
+    const handleFullNameUpdate = fullNameForm.onSubmit((values) => {
+        fullNameMutate.mutate({
+            pathParams: {id: user._id!},
+            //@ts-ignore
+            body: values.fullName
+        }, {
+            onSuccess: () => {
+                queryClient.invalidateQueries().then()
+                notifySuccess("Full name update successful", "Full name changed to " + values.fullName)
+            },
+            onError: (error) =>
+                notifyError("Failed to update full name", getErrorMessage(error))
+        })
+    })
+
+    const handleEmailUpdate = emailForm.onSubmit((values) => {
+        emailMutate.mutate({
+            pathParams: {id: user._id!},
+            //@ts-ignore
+            body: values.email
+
+        }, {
+            onSuccess: () => {
+                queryClient.invalidateQueries().then()
+                notifySuccess("Email update successful", "Email changed to " + values.email)
+            },
+            onError: (error) =>
+                notifyError("Failed to update email", getErrorMessage(error))
+        })
+    })
+
+    const handleOrchidIdUpdate = orchidIdForm.onSubmit((values) => {
+        orchidIdMutate.mutate({
+            pathParams: {id: user._id!},
+            //@ts-ignore
+            body: values.orchidId
+        }, {
+            onSuccess: () => {
+                queryClient.invalidateQueries().then()
+                notifySuccess("Orchid ID update successful", "Orchid ID set to " + values.orchidId)
+            }
+        })
+    })
+
+    const handleHomeInstituteUpdate = homeInstituteForm.onSubmit((values) => {
+        homeInstituteMutate.mutate({
+            pathParams: {id: user._id!},
+            body: {
+                "_id": Number(values.homeInstitute)
+            }
+        }, {
+            onSuccess: () => {
+                queryClient.invalidateQueries().then()
+                notifySuccess("Home Institute update successful",
+                    "Home Institute changed to "
+                    + selectOrganisation.find((org)=>
+                        (org.value === values.homeInstitute))?.label)
+            }
+        })
+    })
+
+
+
+
+
+    if (organisations.isLoading) {
+        return (<Loader/>)
+    }
+
+    if (organisations.isError) {
+        return(
+            <AlertErrorMessage
+                title={"Failed to get Organisations"}
+                error={getErrorMessage(organisations.error)}
+            />
+        )
+    }
+
     return (
-        <Container>
-            <Text>
-                Papa Smurf's Echo Chamber
-            </Text>
-        </Container>
+        <PanelFrame>
+            <PanelHeader itemName={"User Settings"} panelHeading={user.fullName}/>
+            <Fieldset legend={"User Settings"}>
+
+                <Grid columns={12}>
+                    <Grid.Col span={6}>
+                        <Stack>
+                            <form onSubmit={handleFullNameUpdate}>
+                                <Group grow>
+                                    <TextInput
+                                        label={"Full Name"}
+                                        placeholder={"e.g. Jane Doe"}
+                                        {...fullNameForm.getInputProps('fullName')}
+                                    />
+                                    <FormSubmitButton
+                                        form={fullNameForm}
+                                        label={"Update"}
+                                        mt={"1.75em"}
+                                        variant={"filled"}
+                                    />
+                                </Group>
+                            </form>
+                            <form onSubmit={handleEmailUpdate}>
+                                <Group grow>
+                                    <TextInput
+                                        label={"email"}
+                                        placeholder={"e.g. jane.doe@notReal.com"}
+                                        {...emailForm.getInputProps('email')}
+                                    />
+                                    <FormSubmitButton
+                                        form={emailForm}
+                                        label={"Update"}
+                                        mt={"1.75em"}
+                                        variant={"filled"}
+                                    />
+                                </Group>
+                            </form>
+                            <form onSubmit={handleOrchidIdUpdate}>
+                                <Group grow>
+                                    <TextInput
+                                        label={"ORCID id"}
+                                        placeholder={"copy your orchid id here"}
+                                        {...orchidIdForm.getInputProps('orchidId')}
+                                    />
+                                    <FormSubmitButton
+                                        form={orchidIdForm}
+                                        label={"Update"}
+                                        mt={"1.75em"}
+                                        variant={"filled"}
+                                    />
+                                </Group>
+                            </form>
+                        </Stack>
+                    </Grid.Col>
+                    <Grid.Col span={6}>
+                        <Stack>
+                            <form onSubmit={handleHomeInstituteUpdate}>
+                                <Group grow>
+                                    <Select
+                                        label={"Home Institute"}
+                                        placeholder={"select your primary institute"}
+                                        data={selectOrganisation}
+                                        {...homeInstituteForm.getInputProps('homeInstitute')}
+                                    />
+                                    <FormSubmitButton
+                                        form={homeInstituteForm}
+                                        label={"Update"}
+                                        mt={"1.75em"}
+                                        variant={"filled"}
+                                    />
+                                </Group>
+                            </form>
+                            <DisplayOrganisationDetails
+                                organisationId={Number(homeInstituteForm.getValues().homeInstitute)}
+                            />
+                        </Stack>
+                    </Grid.Col>
+                </Grid>
+            </Fieldset>
+        </PanelFrame>
     )
 }

--- a/src/main/webui/src/userManagement.tsx
+++ b/src/main/webui/src/userManagement.tsx
@@ -1,0 +1,13 @@
+import {ReactElement} from "react";
+import {Container, Text} from "@mantine/core";
+
+export default
+function UserManagement() : ReactElement {
+    return (
+        <Container>
+            <Text>
+                Papa Smurf's Echo Chamber
+            </Text>
+        </Container>
+    )
+}

--- a/src/main/webui/src/userManagement.tsx
+++ b/src/main/webui/src/userManagement.tsx
@@ -284,7 +284,7 @@ function UserManagement() : ReactElement {
         <PanelFrame>
             <PanelHeader itemName={"User Settings"} panelHeading={user.fullName}/>
             <Grid columns={12}>
-                <Grid.Col span={5}>
+                <Grid.Col span={{base: 12, xl: 5}}>
                     <Fieldset legend={"Personal Details"}>
                         <form onSubmit={userDetailsForm.onSubmit(handleUserDetailsUpdate)}>
                             <Stack>
@@ -339,7 +339,7 @@ function UserManagement() : ReactElement {
                         </Modal>
                     </Fieldset>
                 </Grid.Col>
-                <Grid.Col span={7}>
+                <Grid.Col span={{base: 12, xl:7}}>
                     <Fieldset legend={"Home Organization"}>
                         <Stack>
                             <form onSubmit={handleHomeInstituteUpdate}>

--- a/src/main/webui/src/userMenu.tsx
+++ b/src/main/webui/src/userMenu.tsx
@@ -1,11 +1,12 @@
 import {ReactElement, useContext} from "react";
-import {ActionIcon, Menu} from "@mantine/core";
+import {ActionIcon, Menu, Tooltip} from "@mantine/core";
 import {
     IconLogout,
     IconUser, IconUserCog
 } from "@tabler/icons-react";
 import {useNavigate} from "react-router-dom";
 import {ProposalContext} from "./App2.tsx";
+import {CLOSE_DELAY, OPEN_DELAY} from "./constants.tsx";
 
 export default
 function UserMenu() : ReactElement {
@@ -19,9 +20,16 @@ function UserMenu() : ReactElement {
             width={200}
         >
             <Menu.Target>
-                <ActionIcon variant={"subtle"}>
-                    <IconUser />
-                </ActionIcon>
+                <Tooltip
+                    label={"open user menu"}
+                    openDelay={OPEN_DELAY}
+                    closeDelay={CLOSE_DELAY}
+                >
+                    <ActionIcon variant={"subtle"}>
+                        <IconUser />
+                    </ActionIcon>
+                </Tooltip>
+
             </Menu.Target>
 
             <Menu.Dropdown>

--- a/src/main/webui/src/userMenu.tsx
+++ b/src/main/webui/src/userMenu.tsx
@@ -1,0 +1,50 @@
+import {ReactElement, useContext} from "react";
+import {ActionIcon, Menu} from "@mantine/core";
+import {
+    IconLogout,
+    IconUser, IconUserCog
+} from "@tabler/icons-react";
+import {useNavigate} from "react-router-dom";
+import {ProposalContext} from "./App2.tsx";
+
+export default
+function UserMenu() : ReactElement {
+
+    const {user} = useContext(ProposalContext);
+    const navigate = useNavigate();
+
+    return (
+        <Menu
+            shadow="md"
+            width={200}
+        >
+            <Menu.Target>
+                <ActionIcon variant={"subtle"}>
+                    <IconUser />
+                </ActionIcon>
+            </Menu.Target>
+
+            <Menu.Dropdown>
+                <Menu.Label>User Management</Menu.Label>
+                <Menu.Item
+                    leftSection={<IconUserCog/>}
+                    onClick={() => navigate("user/" + user._id + "/management")}
+                >
+                    Profile
+                </Menu.Item>
+
+                <Menu.Divider />
+
+                <Menu.Label>Log out</Menu.Label>
+                <Menu.Item
+                    leftSection={<IconLogout/>}
+                    component={"a"}
+                    href={"/pst/gui/logout"}
+                >
+                    log out
+                </Menu.Item>
+
+            </Menu.Dropdown>
+        </Menu>
+    )
+}

--- a/src/main/webui/src/userResetPassword.tsx
+++ b/src/main/webui/src/userResetPassword.tsx
@@ -43,12 +43,13 @@ function getStrength(password: string) {
 export default
 function UserResetPassword() : ReactElement {
 
-    const {user} = useContext(ProposalContext);
+    const {user, getToken} = useContext(ProposalContext);
 
     const passwordMutate = useSubjectMapResourceResetPassword();
 
     const [visible, { toggle }] = useDisclosure(false);
     const [popoverOpened, setPopoverOpened] = useState(false);
+    const [passwordResetSuccess, setPasswordResetSuccess] = useState(false);
     const [newPassword, setNewPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
     const checks = requirements.map((requirement, index) => (
@@ -59,11 +60,16 @@ function UserResetPassword() : ReactElement {
         passwordMutate.mutate({
             pathParams: {personId: user._id!},
             body: newPassword,
-            //@ts-ignore
-            headers: {"Content-Type": "text/plain"}
+
+            headers: {
+                authorization: 'Bearer ' + getToken(),
+                //@ts-ignore
+                "Content-Type": "text/plain"
+            }
         }, {
             onSuccess: () => {
                 notifySuccess("Password updated", "new password set")
+                setPasswordResetSuccess(true);
             },
             onError: (error) => {
                 notifyError("Password update failed", getErrorMessage(error))
@@ -114,11 +120,23 @@ function UserResetPassword() : ReactElement {
                 <Button
                     variant={"filled"}
                     onClick={handleUpdatePassword}
-                    disabled={getStrength(newPassword) < 100 || confirmPassword !== newPassword}
+                    disabled={getStrength(newPassword) < 100 || confirmPassword !== newPassword
+                        || passwordResetSuccess}
                 >
                     Reset Password
                 </Button>
             </Tooltip>
+            {
+                passwordResetSuccess &&
+                <Stack align={'center'}>
+                    <Text c={'green'}>
+                        You have successfully changed your password.
+                    </Text>
+                    <Text c={'yellow'}>
+                        Please now close this modal.
+                    </Text>
+                </Stack>
+            }
         </Stack>
     );
 }

--- a/src/main/webui/src/userResetPassword.tsx
+++ b/src/main/webui/src/userResetPassword.tsx
@@ -83,7 +83,7 @@ function UserResetPassword() : ReactElement {
                     >
                         <PasswordInput
                             withAsterisk
-                            label="Your password"
+                            label="New password"
                             visible={visible}
                             onVisibilityChange={toggle}
                             placeholder="choose new password"
@@ -100,7 +100,7 @@ function UserResetPassword() : ReactElement {
                 </Popover.Dropdown>
             </Popover>
             <PasswordInput
-                label="Confirm password"
+                label="Confirm new password"
                 visible={visible}
                 onVisibilityChange={toggle}
                 value={confirmPassword}
@@ -108,12 +108,13 @@ function UserResetPassword() : ReactElement {
                     setConfirmPassword(event.currentTarget.value)}
             />
             <Tooltip
-                label={confirmPassword !== newPassword ? "Passwords do not match" : "Reset your password"}
+                label={ getStrength(newPassword) < 100 ? "Weak password" :
+                    confirmPassword !== newPassword ? "Passwords do not match" : "Reset your password"}
             >
                 <Button
                     variant={"filled"}
                     onClick={handleUpdatePassword}
-                    disabled={confirmPassword !== newPassword}
+                    disabled={getStrength(newPassword) < 100 || confirmPassword !== newPassword}
                 >
                     Reset Password
                 </Button>

--- a/src/main/webui/src/userResetPassword.tsx
+++ b/src/main/webui/src/userResetPassword.tsx
@@ -1,0 +1,123 @@
+import {ReactElement, useContext, useState} from "react";
+import {Box, Button, PasswordInput, Popover, Progress, Stack, Text, Tooltip} from "@mantine/core";
+import {useDisclosure} from "@mantine/hooks";
+import {IconCheck, IconX} from "@tabler/icons-react";
+import {useSubjectMapResourceResetPassword} from "./generated/proposalToolComponents.ts";
+import {ProposalContext} from "./App2.tsx";
+import {notifyError, notifySuccess} from "./commonPanel/notifications.tsx";
+import getErrorMessage from "./errorHandling/getErrorMessage.tsx";
+
+function PasswordRequirement({ meets, label }: { meets: boolean; label: string }) {
+    return (
+        <Text
+            c={meets ? 'teal' : 'red'}
+            style={{ display: 'flex', alignItems: 'center' }}
+            mt={7}
+            size="sm"
+        >
+            {meets ? <IconCheck size={14} /> : <IconX size={14} />}
+            <Box ml={10}>{label}</Box>
+        </Text>
+    );
+}
+
+const requirements = [
+    { re: /[0-9]/, label: 'Includes number' },
+    { re: /[a-z]/, label: 'Includes lowercase letter' },
+    { re: /[A-Z]/, label: 'Includes uppercase letter' },
+    { re: /[$&+,:;=?@#|'<>.^*()%!-]/, label: 'Includes special symbol' },
+];
+
+function getStrength(password: string) {
+    let multiplier = password.length > 12 ? 0 : 1;
+
+    requirements.forEach((requirement) => {
+        if (!requirement.re.test(password)) {
+            multiplier += 1;
+        }
+    });
+
+    return Math.max(100 - (100 / (requirements.length + 1)) * multiplier, 10);
+}
+
+export default
+function UserResetPassword() : ReactElement {
+
+    const {user} = useContext(ProposalContext);
+
+    const passwordMutate = useSubjectMapResourceResetPassword();
+
+    const [visible, { toggle }] = useDisclosure(false);
+    const [popoverOpened, setPopoverOpened] = useState(false);
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const checks = requirements.map((requirement, index) => (
+        <PasswordRequirement key={index} label={requirement.label} meets={requirement.re.test(newPassword)} />
+    ));
+
+    const handleUpdatePassword = () => {
+        passwordMutate.mutate({
+            pathParams: {personId: user._id!},
+            body: newPassword,
+            //@ts-ignore
+            headers: {"Content-Type": "text/plain"}
+        }, {
+            onSuccess: () => {
+                notifySuccess("Password updated", "new password set")
+            },
+            onError: (error) => {
+                notifyError("Password update failed", getErrorMessage(error))
+            }
+        })
+    }
+
+    const strength = getStrength(newPassword);
+    const color = strength === 100 ? 'teal' : strength > 50 ? 'yellow' : 'red';
+    return (
+        <Stack>
+            <Popover opened={popoverOpened} position="bottom" width="target" transitionProps={{ transition: 'pop' }}>
+                <Popover.Target>
+                    <div
+                        onFocusCapture={() => setPopoverOpened(true)}
+                        onBlurCapture={() => setPopoverOpened(false)}
+                    >
+                        <PasswordInput
+                            withAsterisk
+                            label="Your password"
+                            visible={visible}
+                            onVisibilityChange={toggle}
+                            placeholder="choose new password"
+                            value={newPassword}
+                            onChange={(event) =>
+                                setNewPassword(event.currentTarget.value)}
+                        />
+                    </div>
+                </Popover.Target>
+                <Popover.Dropdown>
+                    <Progress color={color} value={strength} size={5} mb="xs" />
+                    <PasswordRequirement label="Includes at least 12 characters" meets={newPassword.length > 12} />
+                    {checks}
+                </Popover.Dropdown>
+            </Popover>
+            <PasswordInput
+                label="Confirm password"
+                visible={visible}
+                onVisibilityChange={toggle}
+                value={confirmPassword}
+                onChange={(event) =>
+                    setConfirmPassword(event.currentTarget.value)}
+            />
+            <Tooltip
+                label={confirmPassword !== newPassword ? "Passwords do not match" : "Reset your password"}
+            >
+                <Button
+                    variant={"filled"}
+                    onClick={handleUpdatePassword}
+                    disabled={confirmPassword !== newPassword}
+                >
+                    Reset Password
+                </Button>
+            </Tooltip>
+        </Stack>
+    );
+}


### PR DESCRIPTION
Added a "user profile" page to the app where users can update their first and last names, email address, home institute, orchid id, and reset their password. I've implemented a password validator that has several requirements to create a "strong" password.

This also includes a tidy up of the top bar of the app to use a "user menu" that contains a navigation button to the "user profile" page, and the logout button.  This allows for future, additional stuff to be included in that menu.

I've also change the name of the button that navigates to the landing page or as we now call it the user's "home page". 