### PR TITLE
429 an invalid proposal may be submitted

### DIFF
--- a/src/main/webui/src/ProposalEditorView/submitProposal/ValidationOverview.tsx
+++ b/src/main/webui/src/ProposalEditorView/submitProposal/ValidationOverview.tsx
@@ -10,12 +10,13 @@ import {Link, useParams} from "react-router-dom";
 import {PanelFrame} from "../../commonPanel/appearance.tsx";
 import AlertErrorMessage from "../../errorHandling/alertErrorMessage.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
-import {ReactElement} from "react";
+import {ReactElement, useEffect} from "react";
 import React from 'react';
 
 export default function ValidationOverview(props: {
     cycle: number,
-    smallScreen?: boolean
+    smallScreen?: boolean,
+    setProposalCheck: React.Dispatch<React.SetStateAction<boolean>>
 }): ReactElement {
 
     const { selectedProposalCode } = useParams();
@@ -35,6 +36,12 @@ export default function ValidationOverview(props: {
     const observatory = useProposalCyclesResourceGetProposalCycleObservatory({
             pathParams: {cycleCode: props.cycle}
         })
+
+    useEffect(() => {
+        if (validateProposal.status === 'success') {
+            props.setProposalCheck(validateProposal.data.isValid!)
+        }
+    }, [validateProposal]);
 
     if (validateProposal.isLoading || cycleTitle.isLoading || cycleDates.isLoading || observatory.isLoading) {
         return(

--- a/src/main/webui/src/ProposalEditorView/submitProposal/ValidationOverview.tsx
+++ b/src/main/webui/src/ProposalEditorView/submitProposal/ValidationOverview.tsx
@@ -78,21 +78,21 @@ export default function ValidationOverview(props: {
         );
     }
 
-    const formatTextWithLinks = (text: string) : ReactElement => {
+    const formatTextWithLinks = (p : {text: string, color: string}) : ReactElement => {
         return (
             <Table.Td>
-                {text.replace('<br/>$', 'g')
+                {p.text.replace('<br/>$', 'g')
                 .split("<br/>")
                 .map((s, index) => (
                     s.length > 0 &&
                     <React.Fragment key={index}>
                         {s.includes("No observations defined")||s.includes("A timing window for")?
-                            <NavLink to={"/proposal/"+selectedProposalCode+"/observations"} component={Link} label={s} />
+                            <NavLink to={"/proposal/"+selectedProposalCode+"/observations"} component={Link} label={s} c={p.color} />
                             :s.includes("No targets defined")?
-                                <NavLink to={"/proposal/"+selectedProposalCode+"/targets"} component={Link} label={s} />
+                                <NavLink to={"/proposal/"+selectedProposalCode+"/targets"} component={Link} label={s} c={p.color}/>
                                 :s.includes("No technical goals defined")?
-                                    <NavLink to={"/proposal/"+selectedProposalCode+"/goals"} component={Link} label={s} />
-                                    :<Text size={"sm"}>{s}</Text>}
+                                    <NavLink to={"/proposal/"+selectedProposalCode+"/goals"} component={Link} label={s} c={p.color}/>
+                                    :<Text size={"sm"} c={p.color}>{s}</Text>}
                     </React.Fragment>
                 ))}
             </Table.Td>)
@@ -121,27 +121,30 @@ export default function ValidationOverview(props: {
                         <Table.Tr>
                             <Table.Td>
                                 {validateProposal.data?.isValid?
-                                    (<IconCircleCheck size={ICON_SIZE} />):
-                                    (<IconInfoCircle size={ICON_SIZE} />)
+                                    (<IconCircleCheck size={ICON_SIZE} color={'green'}/>):
+                                    (<IconInfoCircle size={ICON_SIZE} color={'orange'}/>)
                                 }
                             </Table.Td>
                             <Table.Td>
-                                {validateProposal.data?.info && formatTextWithLinks(validateProposal.data?.info)}
+                                {validateProposal.data?.info &&
+                                    formatTextWithLinks({text: validateProposal.data?.info,
+                                        color: validateProposal.data?.isValid ? 'green' : 'orange'})
+                                }
                             </Table.Td>
                         </Table.Tr>
                         {validateProposal.data?.warnings !== undefined &&
                             (<Table.Tr>
                                 <Table.Td>
-                                    <IconAlertCircle size={ICON_SIZE} />
+                                    <IconAlertCircle size={ICON_SIZE} color={'orange'}/>
                                 </Table.Td>
-                                {formatTextWithLinks(validateProposal.data.warnings)}
+                                {formatTextWithLinks({text: validateProposal.data.warnings, color: 'orange'})}
                             </Table.Tr>)}
                         {validateProposal.data?.errors !== undefined &&
                             (<Table.Tr>
                                 <Table.Td>
-                                    <IconCircleX size={ICON_SIZE} />
+                                    <IconCircleX size={ICON_SIZE} color={'red'}/>
                                 </Table.Td>
-                                {formatTextWithLinks(validateProposal.data.errors)}
+                                {formatTextWithLinks({text: validateProposal.data.errors, color: 'red'})}
                             </Table.Tr>)}
                     </Table.Tbody>
                 </Table>

--- a/src/main/webui/src/ProposalEditorView/submitProposal/observationModeDetailsShow.tsx
+++ b/src/main/webui/src/ProposalEditorView/submitProposal/observationModeDetailsShow.tsx
@@ -339,7 +339,7 @@ function ObservationModeDetailsShow(p: {
                             <ActionIcon
                                 onClick={toggle}
                             >
-                                {opened ? <IconEye /> : <IconEyeClosed />}
+                                {opened ? <IconEyeClosed /> : <IconEye />}
                             </ActionIcon>
                         </Tooltip>
                         <Button


### PR DESCRIPTION
Added logic to prevent a proposal with no observations being allowed to submit to a proposal cycle (thinking about it, this should also be prevented in the API).

I've also made some functional tweaks, such as disabling the "Next Step" button when no cycle is selected, if the proposal does not pass the basic checks, and if the user has not selected observing modes for all their observations. This includes adding relevant tool-tip messages for the "Next Step" button.

Additionally, I have included visual tweak to the validation messages being displayed in different colours depending on their "severity": green for okay, orange for warnings, red for errors.