### PR TITLE
make timing windows an optional input to observations

### DIFF
--- a/src/main/webui/public/contextualHelpMessages.jsx
+++ b/src/main/webui/public/contextualHelpMessages.jsx
@@ -122,8 +122,8 @@ export const contextualHelpMessages = [
     message: " "
         + " Select the 'type' observation, either 'Target' or 'Calibration'. "
         + " A 'Calibration Observation' requires you pick an intended use e.g., Pointing, Bandpass, etc."
-        + " You must select at least one Target, and one Technical Goal. "
-        + " At least one 'Timing Window' is required. Here you must provide start and end dates-times for the window. "
+        + " You must select at least one Target, and exactly one Technical Goal. "
+        + " 'Timing Windows' are optional. If you must provide one then you have to define both start and end dates-times for the window. "
         + " Notice that the end date-time must be after the start date-time. "
         + " The semantics of the avoid flag is to communicate a timing window that must be avoided for this observation. You may also add a brief optional note."
   }, {

--- a/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
@@ -1,7 +1,7 @@
 import TargetTypeForm from "./targetType.form.tsx";
 import TimingWindowsForm from "./timingWindows.form.tsx";
 import {ObservationProps} from "./observationPanel.tsx";
-import {Fieldset, Text, Group, Stack} from '@mantine/core';
+import {Fieldset, Text, Group, Tabs} from '@mantine/core';
 import {
     CalibrationObservation,
     CalibrationTargetIntendedUse, Observation, Target, TargetObservation,
@@ -25,7 +25,7 @@ import { TimingWindowGui } from './timingWindowGui.tsx';
 import {notifyError, notifySuccess} from "../../commonPanel/notifications.tsx";
 import getErrorMessage from "../../errorHandling/getErrorMessage.tsx";
 import {queryKeyProposals} from "../../queryKeyProposals.tsx";
-import {err_red_str, NO_ROW_SELECTED} from "../../constants.tsx";
+import {err_green_str, NO_ROW_SELECTED} from "../../constants.tsx";
 import {ContextualHelpButton} from "../../commonButtons/contextualHelp.tsx";
 
 /**
@@ -182,12 +182,6 @@ function ObservationEditGroup(props: ObservationProps): ReactElement {
                 calibrationUse: (value, values) =>
                     ((values.observationType === "Calibration" && value === undefined) ?
                         'Please select the calibration use' : null),
-                timingWindows : {
-                    startTime: (value) => (
-                        value === null ? 'No start time selected' : null),
-                    endTime: (value) => (
-                        value === null ? 'No end time selected' : null)
-                }
             },
     });
 
@@ -429,30 +423,41 @@ function ObservationEditGroup(props: ObservationProps): ReactElement {
 
   return (
     <form onSubmit={handleSubmit}>
-        <Stack>
-            <ContextualHelpButton messageId={"MaintObs"} />
-            <TargetTypeForm form={form} setFieldName={setFieldName}/>
-            <Fieldset legend={"Timing windows"}>
-                <Text ta={"center"} size={"xs"} c={"gray.6"}>
-                    Timezone set to UTC
-                </Text>
-                {
-                    form.getValues().timingWindows.length === 0 &&
-                    <Text ta={'center'} c={err_red_str} size={"sm"}>
-                        Please define at least one Timing Window
-                    </Text>
-                }
+        <ContextualHelpButton messageId={"MaintObs"} />
+        <Tabs defaultValue={'targetType'} variant={'outline'}>
+            <Tabs.List>
+                <Tabs.Tab value={'targetType'}>
+                    Type, Target(s), & Technical Goal
+                </Tabs.Tab>
 
-                <TimingWindowsForm form={form}/>
-            </Fieldset>
-            <Group justify={"flex-end"}>
-                <FormSubmitButton form={form} disabled={form.getValues().timingWindows.length === 0}/>
-                <CancelButton
-                    onClickEvent={handleCancel}
-                    toolTipLabel={"Go back without saving"}
-                />
-            </Group>
-        </Stack>
+                <Tabs.Tab value={'timingWindows'}>
+                    Timing Windows (optional)
+                </Tabs.Tab>
+            </Tabs.List>
+
+            <Tabs.Panel value={'targetType'} mt={'sm'}>
+                <TargetTypeForm form={form} setFieldName={setFieldName}/>
+            </Tabs.Panel>
+
+            <Tabs.Panel value={'timingWindows'}>
+                <Fieldset legend={"Timing windows"}>
+                    <Text ta={"center"} size={"xs"} c={err_green_str}>
+                        Timing Windows are optional
+                    </Text>
+                    <Text ta={"center"} size={"xs"} c={"gray.6"}>
+                        Timezone set to UTC
+                    </Text>
+                    <TimingWindowsForm form={form}/>
+                </Fieldset>
+            </Tabs.Panel>
+        </Tabs>
+        <Group justify={"flex-end"}>
+            <FormSubmitButton form={form}/>
+            <CancelButton
+                onClickEvent={handleCancel}
+                toolTipLabel={"Go back without saving"}
+            />
+        </Group>
     </form>
     )
 }


### PR DESCRIPTION
Does this, plus updated the contextual help message to reflect this change