### PR TITLE
481 issue with datetimepicker used in forms

### DIFF
--- a/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
@@ -416,11 +416,6 @@ function ObservationEditGroup(props: ObservationProps): ReactElement {
       props.closeModal!();
   }
 
-  /*
-    Might be worth splitting this into two forms: one for the Target(s) and type for the Observation, the
-    other for the Timing Windows. Then we could split these across Tabs in the modal.
-   */
-
   return (
     <form onSubmit={handleSubmit}>
         <ContextualHelpButton messageId={"MaintObs"} />

--- a/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/edit.group.tsx
@@ -60,8 +60,8 @@ export interface ObservationFormValues {
  */
 function ConvertToTimingWindowGui(input: TimingWindow) : TimingWindowGui {
     return ({
-        startTime: new Date(input.startTime!),
-        endTime: new Date(input.endTime!),
+        startTime: input.startTime!,
+        endTime: input.endTime!,
         note: input.note ?? "",
         isAvoidConstraint: input.isAvoidConstraint!,
         key: String(input._id!),
@@ -81,8 +81,8 @@ function ConvertToTimingWindowGui(input: TimingWindow) : TimingWindowGui {
 function ConvertToTimingWindowApi(input: TimingWindowGui) : TimingWindowApi {
     return ({
         "@type": "proposal:TimingWindow",
-        startTime: input.startTime!.getTime(),
-        endTime: input.endTime!.getTime(),
+        startTime: new Date(input.startTime!).getTime(),
+        endTime: new Date(input.endTime!).getTime(),
         note: input.note,
         isAvoidConstraint: input.isAvoidConstraint,
         _id: input.id

--- a/src/main/webui/src/ProposalEditorView/observations/timingWindowGui.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/timingWindowGui.tsx
@@ -1,15 +1,15 @@
 //type to use for the DateTimePickers
 /**
- * @param {Date | null} startTime the date the timing window will begin.
- * @param {Date | null} endTime the date the timing window will end.
+ * @param {string | null} startTime the date the timing window will begin.
+ * @param {string | null} endTime the date the timing window will end.
  * @param {string} note the optional note.
  * @param {boolean} isAvoidConstraint
  * @param {string} key the primary key in the database or a random string if new.
  * @param {number} id the database id for the window or zero if new
  */
 export type TimingWindowGui = {
-    startTime: Date | null,
-    endTime: Date | null,
+    startTime: string | null,
+    endTime: string | null,
     note: string,
     isAvoidConstraint: boolean,
     key: string,

--- a/src/main/webui/src/ProposalEditorView/observations/timingWindows.form.tsx
+++ b/src/main/webui/src/ProposalEditorView/observations/timingWindows.form.tsx
@@ -164,7 +164,7 @@ export default function TimingWindowsForm(
                                     valueFormat={"YYYY/MM/DD HH:mm"}
                                     placeholder={"end time - YYYY/MM/DD HH:mm"}
                                     minDate={tw.startTime != null?
-                                        new Date() > tw.startTime ?
+                                        new Date() > new Date(tw.startTime) ?
                                             new Date() : tw.startTime
                                         : new Date()}
                                     {...form.getInputProps(

--- a/src/main/webui/src/ProposalManagerView/proposalCycle.new.form.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle.new.form.tsx
@@ -28,9 +28,9 @@ export default function NewCycleForm({closeModal}: NewCycleFormProps): ReactElem
     interface NewCycleFormType {
         title: string,
         cycleCode: string,
-        submissionDeadline: Date | null,
-        sessionStart: Date | null,
-        sessionEnd: Date | null,
+        submissionDeadline: string | null,
+        sessionStart: string | null,
+        sessionEnd: string | null,
         observatoryId: number | null,
         sourceCycleId: string | null,
         observingHours: number | null
@@ -182,9 +182,11 @@ export default function NewCycleForm({closeModal}: NewCycleFormProps): ReactElem
                         }
                     ]
                 },
-                submissionDeadline: values.submissionDeadline!.getTime().toString(),
-                observationSessionStart: values.sessionStart!.getTime().toString(),
-                observationSessionEnd: values.sessionEnd!.getTime().toString(),
+                //API does not like date-time strings, we convert to no. of ms from posix epoch, then
+                // stringify that number to appease the TypeScript gods
+                submissionDeadline: new Date(values.submissionDeadline!).getTime().toString(),
+                observationSessionStart: new Date(values.sessionStart!).getTime().toString(),
+                observationSessionEnd: new Date(values.sessionEnd!).getTime().toString(),
             }
 
             sourceCycleIdRef.current = values.sourceCycleId;

--- a/src/main/webui/src/ProposalManagerView/proposalCycle/details.tsx
+++ b/src/main/webui/src/ProposalManagerView/proposalCycle/details.tsx
@@ -20,9 +20,9 @@ export default function CycleDatesPanel() : ReactElement {
     interface updateDatesForm {
         title: string,
         code: string,
-        submissionDeadline: Date | null,
-        sessionStart: Date | null,
-        sessionEnd: Date | null
+        submissionDeadline: string | null,
+        sessionStart: string | null,
+        sessionEnd: string | null
     }
 
     if(!HaveRole(["tac_admin", "tac_member"])) {
@@ -67,12 +67,12 @@ export default function CycleDatesPanel() : ReactElement {
 
     useEffect(() => {
         if (details.status === 'success') {
-            setCycleTitle(details.data?.title as string);
-            form.values.title = details.data.title as string;
-            form.values.code = details.data?.code as string;
-            form.values.submissionDeadline = new Date(details.data?.submissionDeadline as string);
-            form.values.sessionStart = new Date(details.data?.observationSessionStart as string);
-            form.values.sessionEnd = new Date(details.data?.observationSessionEnd as string);
+            setCycleTitle(details.data?.title!);
+            form.values.title = details.data.title!;
+            form.values.code = details.data?.code!;
+            form.values.submissionDeadline = details.data?.submissionDeadline!;
+            form.values.sessionStart = details.data?.observationSessionStart!;
+            form.values.sessionEnd = details.data?.observationSessionEnd!;
         }
     }, [details.status,details.data]);
 
@@ -108,9 +108,9 @@ export default function CycleDatesPanel() : ReactElement {
             body: {
                 title: form.values.title,
                 code: form.values.code,
-                submissionDeadline: form.values.submissionDeadline?.getTime().toString(),
-                observationSessionStart: form.values.sessionStart?.getTime().toString(),
-                observationSessionEnd: form.values.sessionEnd?.getTime().toString(),
+                submissionDeadline: new Date(form.values.submissionDeadline!).getTime().toString(),
+                observationSessionStart: new Date(form.values.sessionStart!).getTime().toString(),
+                observationSessionEnd: new Date(form.values.sessionEnd!).getTime().toString(),
                 observatory: details.data?.observatory
             }
         })


### PR DESCRIPTION
Mantine v7 -> v8 changed the type used in their DateTimePicker from Date objects to date-time strings. I've made changes to the code that uses the DateTimePicker component to accept those inputs as strings and to convert to Date objects when required. Parts affected: TimingWindows for Observations, and dates involved with ProposalCycles.